### PR TITLE
remove install of yarn from action (because it is already installed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,6 @@ jobs:
         with:
           version: 10.x
 
-      - name: Install Yarn
-        run: npm install --global yarn
-
       - name: Install Dependencies
         run: yarn
 
@@ -65,10 +62,6 @@ jobs:
         uses: actions/setup-node@master
         with:
           version: 10.x
-
-      - name: Install Yarn
-        run: npm install --global yarn
-
       - name: Install Dependencies
         run: yarn
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ jobs:
         uses: actions/setup-node@master
         with:
           version: 10.x
+
       - name: Install Dependencies
         run: yarn
 


### PR DESCRIPTION
As you can see [in this action I have on one of my repos](https://github.com/ChristopherBiscardi/gatsby-plugins/blob/a6368670fd98c0950036d7ddab920fccbf3dce89/.github/workflows/npmpublish.yml#L8-L17), yarn is already installed by the `setup-node` action and so doesn't need to be re-installed