### PR TITLE
Do not throw if CHANGELOG.md doesn't exist

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -249,6 +249,12 @@ ${
         (
           await Promise.all(
             changedPackages.map(async (pkg) => {
+              
+              const changelogPath = path.join(pkg.dir, "CHANGELOG.md");
+              if (!fs.pathExists(changelogPath)) {
+                return;
+              }
+
               let changelogContents = await fs.readFile(
                 path.join(pkg.dir, "CHANGELOG.md"),
                 "utf8"
@@ -258,6 +264,11 @@ ${
                 changelogContents,
                 pkg.packageJson.version
               );
+
+              if (!entry.content) {
+                return;
+              }
+
               return {
                 highestLevel: entry.highestLevel,
                 private: !!pkg.packageJson.private,
@@ -268,7 +279,7 @@ ${
             })
           )
         )
-          .filter((x) => x)
+          .filter((x): x is { highestLevel: number; private: boolean; content: string; } => !!x)
           .sort(sortTheThings)
           .map((x) => x.content)
           .join("\n ")


### PR DESCRIPTION
Fixes 2 issues:
1. PR is not created if CHANGELOG.md doesn't exist for a changed package. It could happen when the package is ignored, or only devDependencies are updated and the package doesn't have CAHNGELOG.md ( it could be new package, or an internal package that shouldn't have a CHANGELOG.md)

2. We incorrectly display packages that are updated, but don't have changelog entries (means it's not released) in the PR body. It could happen when the package is ignored, or only devDependencies are updated.