### PR TITLE
fix: remove git global config flag

### DIFF
--- a/src/gitUtils.ts
+++ b/src/gitUtils.ts
@@ -4,13 +4,11 @@ import { execWithOutput } from "./utils";
 export const setupUser = async () => {
   await exec("git", [
     "config",
-    "--global",
     "user.name",
     `"github-actions[bot]"`,
   ]);
   await exec("git", [
     "config",
-    "--global",
     "user.email",
     `"github-actions[bot]@users.noreply.github.com"`,
   ]);


### PR DESCRIPTION
Running this action inside a self-hosted GitHub runner that has an Alpine equivalent barebones environment, the changeset action fails since it's trying to set git user & email on global config that looks for `$HOME/.gitconfig`.

Self-hosted instances might also have a shared VM running multiple jobs, updating global git config might pollute the global configs which is not expected.

![image](https://user-images.githubusercontent.com/5961873/119644795-ee47de00-be3a-11eb-894a-becaf3a2c95f.png)
