### PR TITLE
add git commit signing

### DIFF
--- a/.changeset/silly-jokes-refuse.md
+++ b/.changeset/silly-jokes-refuse.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": minor
+---
+
+Add support for commit signing with a GPG key

--- a/README.md
+++ b/README.md
@@ -175,3 +175,26 @@ If you are using [Yarn Plug'n'Play](https://yarnpkg.com/features/pnp), you shoul
     version: yarn changeset version
     ...
 ```
+
+#### With Git commit signing
+
+If you would like to have the commits signed in the pull request, this action supports [commit signature verification using GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification).
+
+To enable this:
+
+1. Add your GPG private key as a GitHub secret
+2. Pass the secret in as the `GPG_PRIVATE_KEY` env variable
+3. Pass in the associated email with the `gitUserEmail` input
+4. (Optional) pass in a user name for the commits
+
+```yaml
+- uses: changesets/action@v1
+  env:
+    GPG_PRIVATE_KEY: ${{ secrets.GPG_SIGN_KEY }}
+  with:
+    gitUserEmail: 'octocat@github.com'
+    gitUserName: 'octocat'
+    ...
+```
+
+> Note: GPG needs to be installed on whichever image you're using in your GitHub action.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This action for [Changesets](https://github.com/atlassian/changesets) creates a 
 - version - The command to update version, edit CHANGELOG, read and delete changesets. Default to `changeset version` if not provided
 - commit - The commit message to use. Default to `Version Packages`
 - title - The pull request title. Default to `Version Packages`
-- githubUserName - The GitHub user name on commits. Default to `"github-actions[bot]"`
-- githubUserEmail - The GitHub user email on commits. Default to `"github-actions[bot]@users.noreply.github.com"`
+- gitUserName - The Git user name on commits. Default to `"github-actions[bot]"`
+- gitUserEmail - The Git user email on commits. Default to `"github-actions[bot]@users.noreply.github.com"`
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This action for [Changesets](https://github.com/atlassian/changesets) creates a 
 - version - The command to update version, edit CHANGELOG, read and delete changesets. Default to `changeset version` if not provided
 - commit - The commit message to use. Default to `Version Packages`
 - title - The pull request title. Default to `Version Packages`
+- githubUserName - The GitHub user name on commits. Default to `"github-actions[bot]"`
+- githubUserEmail - The GitHub user email on commits. Default to `"github-actions[bot]@users.noreply.github.com"`
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,12 @@ inputs:
   title:
     description: The pull request title. Default to `Version Packages`
     required: false
+  githubUserName:
+    description: The GitHub user name on commits. Default to `"github-actions[bot]"`
+    required: false
+  githubUserEmail:
+    description: The GitHub user email on commits. Default to `"github-actions[bot]@users.noreply.github.com"`
+    required: false
 outputs:
   published:
     description: A boolean value to indicate whether a publishing is happened or not

--- a/action.yml
+++ b/action.yml
@@ -17,11 +17,11 @@ inputs:
   title:
     description: The pull request title. Default to `Version Packages`
     required: false
-  githubUserName:
-    description: The GitHub user name on commits. Default to `"github-actions[bot]"`
+  gitUserName:
+    description: The Git user name on commits. Default to `"github-actions[bot]"`
     required: false
-  githubUserEmail:
-    description: The GitHub user email on commits. Default to `"github-actions[bot]@users.noreply.github.com"`
+  gitUserEmail:
+    description: The Git user email on commits. Default to `"github-actions[bot]@users.noreply.github.com"`
     required: false
 outputs:
   published:

--- a/src/gitUtils.ts
+++ b/src/gitUtils.ts
@@ -1,42 +1,20 @@
 import { exec } from "@actions/exec";
 import { execWithOutput } from "./utils";
 
-export const setupUser = async (githubUserName: string, githubUserEmail: string) => {
-  await exec("git", [
-    "config",
-    "--global",
-    "user.name",
-    githubUserName,
-  ]);
-  await exec("git", [
-    "config",
-    "--global",
-    "user.email",
-    githubUserEmail,
-  ]);
+export const setupUser = async({ name, email }: { name: string; email: string; }) => {
+  await exec("git", ["config", "--global", "user.name", name]);
+  await exec("git", ["config", "--global", "user.email", email]);
 };
 
 export const setupCommitSigning = async (gpgPrivateKey: string) => {
-  await exec("apk", [
-    "add",
-    "--no-cache",
-    "gnupg",
-  ]);
+  await exec("apk", ["add", "--no-cache", "gnupg"]);
   await exec("gpg", ["--import"], { input: Buffer.from(gpgPrivateKey) });
-  const { stdout: keyId } = await execWithOutput(`/bin/bash -c "gpg --list-secret-keys --with-colons | grep '^sec:' | cut -d ':' -f 5"`);
-  await exec("git", [
-    "config",
-    "--global",
-    "user.signingkey",
-    keyId.trim(),
-  ]);
-  await exec("git", [
-    "config",
-    "--global",
-    "commit.gpgsign",
-    "true",
-  ]);
-}
+  const { stdout: keyId } = await execWithOutput(
+    `/bin/bash -c "gpg --list-secret-keys --with-colons | grep '^sec:' | cut -d ':' -f 5"`
+  );
+  await exec("git", ["config", "--global", "user.signingkey", keyId.trim()]);
+  await exec("git", ["config", "--global", "commit.gpgsign", "true"]);
+};
 
 export const pullBranch = async (branch: string) => {
   await exec("git", ["pull", "origin", branch]);

--- a/src/gitUtils.ts
+++ b/src/gitUtils.ts
@@ -7,7 +7,6 @@ export const setupUser = async({ name, email }: { name: string; email: string; }
 };
 
 export const setupCommitSigning = async (gpgPrivateKey: string) => {
-  await exec("apk", ["add", "--no-cache", "gnupg"]);
   await exec("gpg", ["--import"], { input: Buffer.from(gpgPrivateKey) });
   const { stdout: keyId } = await execWithOutput(
     `/bin/bash -c "gpg --list-secret-keys --with-colons | grep '^sec:' | cut -d ':' -f 5"`

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,12 +14,12 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
     return;
   }
 
-  let githubUserName = getOptionalInput('githubUserName') || `"github-actions[bot]"`;
-  let githubUserEmail = getOptionalInput('githubUserEmail') || `"github-actions[bot]@users.noreply.github.com"`;
+  const gitUserName = getOptionalInput("gitUserName") || `"github-actions[bot]"`;
+  const gitUserEmail = getOptionalInput("gitUserEmail") || `"github-actions[bot]@users.noreply.github.com"`;
 
   console.log("setting git user");
- 
-  await gitUtils.setupUser(githubUserName, githubUserEmail);
+
+  await gitUtils.setupUser({ name: gitUserName, email: gitUserEmail });
 
   const gpgPrivateKey = process.env.GPG_PRIVATE_KEY;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,8 +14,19 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
     return;
   }
 
+  let githubUserName = getOptionalInput('githubUserName') || `"github-actions[bot]"`;
+  let githubUserEmail = getOptionalInput('githubUserEmail') || `"github-actions[bot]@users.noreply.github.com"`;
+
   console.log("setting git user");
-  await gitUtils.setupUser();
+ 
+  await gitUtils.setupUser(githubUserName, githubUserEmail);
+
+  const gpgPrivateKey = process.env.GPG_PRIVATE_KEY;
+
+  if (gpgPrivateKey) {
+    console.log("using provided gpg private key for commit signing");
+    await gitUtils.setupCommitSigning(gpgPrivateKey);
+  }
 
   console.log("setting GitHub credentials");
   await fs.writeFile(


### PR DESCRIPTION
# Context

Fixes #126 

# Changes

- Add a `githubUserName` input option
  - Default to `"github-actions[bot]"`
- Add a `githubUserEmail` input option
  - Default to `"github-actions[bot]@users.noreply.github.com"`
- Add a `GPG_PRIVATE_KEY` env option
  - This determines if keys should be signed or not
- Pass in `githubUserName` and `githubUserEmail` to `setupUser`
  - Can be done outwith signed commits, but these are needed to verify the signed commits if its enabled
- Add a `setupCommitSigning` if `GPG_PRIVATE_KEY` is present
  - Need to install `gpg`
  - use `STDIN` for `gpg --import` (utf-8 encoding with `Buffer.from` by default)
  - Need to do a `/bin/bash` command to get and grep the key id - `exec` doesn't support piping and multiple commands on its own
  - Set `git` config for `user.signingkey` and `commit.gpgsign`

# Considerations

- Input option naming (`githubUserName` vs `github_user_name`)
- Should the input options just be more `env` variables instead?]
- How do you feel about installing `gpg` here?