### PR TITLE
custom git user input option

### DIFF
--- a/.changeset/two-dolls-promise.md
+++ b/.changeset/two-dolls-promise.md
@@ -2,4 +2,4 @@
 "@changesets/action": minor
 ---
 
-add a `setupGitUser` to enable or disable setting up a default git user
+Added `setupGitUser` option to enable or disable setting up a default git user

--- a/.changeset/two-dolls-promise.md
+++ b/.changeset/two-dolls-promise.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": patch
+---
+
+add an input option to allow custom git users

--- a/.changeset/two-dolls-promise.md
+++ b/.changeset/two-dolls-promise.md
@@ -2,4 +2,4 @@
 "@changesets/action": minor
 ---
 
-add an input option to allow custom git users
+add a `setupGitUser` to enable or disable setting up a default git user

--- a/.changeset/two-dolls-promise.md
+++ b/.changeset/two-dolls-promise.md
@@ -1,5 +1,5 @@
 ---
-"@changesets/action": patch
+"@changesets/action": minor
 ---
 
 add an input option to allow custom git users

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This action for [Changesets](https://github.com/atlassian/changesets) creates a 
 - version - The command to update version, edit CHANGELOG, read and delete changesets. Default to `changeset version` if not provided
 - commit - The commit message to use. Default to `Version Packages`
 - title - The pull request title. Default to `Version Packages`
+- setupGitUser - Sets up the git user for commits as `"github-actions[bot]"`. Default to `true`
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
   title:
     description: The pull request title. Default to `Version Packages`
     required: false
+  customGitUser:
+    description: Use a custom git user to create commits, rather than the default `"github-actions[bot]"` user.
+    required: false
 outputs:
   published:
     description: A boolean value to indicate whether a publishing is happened or not

--- a/action.yml
+++ b/action.yml
@@ -17,9 +17,10 @@ inputs:
   title:
     description: The pull request title. Default to `Version Packages`
     required: false
-  customGitUser:
-    description: Use a custom git user to create commits, rather than the default `"github-actions[bot]"` user.
+  setupGitUser:
+    description: Sets up the git user for commits as `"github-actions[bot]"`. Default to `true`
     required: false
+    default: true
 outputs:
   published:
     description: A boolean value to indicate whether a publishing is happened or not

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "release": "node ./scripts/release.js"
   },
   "dependencies": {
-    "@actions/core": "^1.2.4",
+    "@actions/core": "^1.3.0",
     "@actions/exec": "^1.1.0",
     "@actions/github": "^4.0.0",
     "@babel/core": "^7.13.10",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,8 +14,12 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
     return;
   }
 
-  console.log("setting git user");
-  await gitUtils.setupUser();
+  let customGitUser = getOptionalInput("customGitUser");
+
+  if (!customGitUser) {
+    console.log("setting git user");
+    await gitUtils.setupUser();
+  }
 
   console.log("setting GitHub credentials");
   await fs.writeFile(

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,9 +14,9 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
     return;
   }
 
-  let customGitUser = getOptionalInput("customGitUser");
+  let setupGitUser = core.getBooleanInput('setupGitUser');
 
-  if (!customGitUser) {
+  if (setupGitUser) {
     console.log("setting git user");
     await gitUtils.setupUser();
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,12 @@
 # yarn lockfile v1
 
 
-"@actions/core@^1.2.4":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.2.4.tgz#96179dbf9f8d951dd74b40a0dbd5c22555d186ab"
-  integrity sha512-YJCEq8BE3CdN8+7HPZ/4DxJjk/OkZV2FFIf+DlZTC/4iBlzYCD5yjRR6eiOS5llO11zbRltIRuKAjMKaWTE6cg==
+"@actions/core@^1.3.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.6.0.tgz#0568e47039bfb6a9170393a73f3b7eb3b22462cb"
+  integrity sha512-NB1UAZomZlCV/LmJqkLhNTqtKfFXJZAUPcfl/zqG7EfsQdeUJtaWO98SGbuQ3pydJ3fHl2CvI/51OKYlCYYcaw==
+  dependencies:
+    "@actions/http-client" "^1.0.11"
 
 "@actions/exec@^1.1.0":
   version "1.1.0"
@@ -23,6 +25,13 @@
     "@octokit/core" "^3.0.0"
     "@octokit/plugin-paginate-rest" "^2.2.3"
     "@octokit/plugin-rest-endpoint-methods" "^4.0.0"
+
+"@actions/http-client@^1.0.11":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@actions/http-client/-/http-client-1.0.11.tgz#c58b12e9aa8b159ee39e7dd6cbd0e91d905633c0"
+  integrity sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==
+  dependencies:
+    tunnel "0.0.6"
 
 "@actions/http-client@^1.0.8":
   version "1.0.8"


### PR DESCRIPTION
# Context

Fixes #126, alternative solution to #127

Instead of implementing git commit signing into the action, we could allow an input option to disable the `setupUser` function so that consumers can use their own git user to create commits in this action.

# Changes

- Add `setupGitUser` boolean input option
  - Updated `@actions/core` to be able to use `getBooleanInput`
  - Default to `true`
- Don't run `gitUtils.setupUser()` if `setupGitUser` is `false`
- Update docs