### PR TITLE
fix output flag `published` is always `false` when used with `changeset publish --no-git-tag`

### DIFF
--- a/.changeset/mean-buttons-fly.md
+++ b/.changeset/mean-buttons-fly.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": patch
+---
+
+Fix a bug where the output flag `published` is set to `false` when no tags being created by the publishing process.

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,11 +89,14 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
 
       if (result.published) {
         core.setOutput("published", "true");
+      }
+      if (result.publishedPackages.length !== 0) {
         core.setOutput(
           "publishedPackages",
           JSON.stringify(result.publishedPackages)
         );
       }
+
       return;
     }
     case hasChangesets:

--- a/src/run.ts
+++ b/src/run.ts
@@ -57,14 +57,10 @@ type PublishOptions = {
 
 type PublishedPackage = { name: string; version: string };
 
-type PublishResult =
-  | {
-      published: true;
-      publishedPackages: PublishedPackage[];
-    }
-  | {
-      published: false;
-    };
+type PublishResult = {
+  published: boolean;
+  publishedPackages: PublishedPackage[];
+};
 
 export async function runPublish({
   script,
@@ -142,17 +138,16 @@ export async function runPublish({
     }
   }
 
+  const result: PublishResult = { published: true, publishedPackages: [] };
+
   if (releasedPackages.length) {
-    return {
-      published: true,
-      publishedPackages: releasedPackages.map((pkg) => ({
-        name: pkg.packageJson.name,
-        version: pkg.packageJson.version,
-      })),
-    };
+    result.publishedPackages = releasedPackages.map((pkg) => ({
+      name: pkg.packageJson.name,
+      version: pkg.packageJson.version,
+    }));
   }
 
-  return { published: false };
+  return result;
 }
 
 const requireChangesetsCliPkgJson = (cwd: string) => {


### PR DESCRIPTION
Fix #141 