### PR TITLE
add `pushGitTags` input option

### DIFF
--- a/.changeset/fast-flies-wink.md
+++ b/.changeset/fast-flies-wink.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": minor
+---
+
+Added `pushGitTags` input option (defaults to `true`) to control whether to push created Git tags or not.

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: "A boolean value to indicate whether to create Github releases after `publish` or not"
     required: false
     default: true
+  pushGitTags:
+    description: "A boolean value to indicate whether to push Git tags or not"
+    required: false
+    default: true
 outputs:
   published:
     description: A boolean value to indicate whether a publishing is happened or not

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
       const result = await runPublish({
         script: publishScript,
         githubToken,
+        pushGitTags: core.getBooleanInput("pushGitTags"),
         createGithubReleases: core.getBooleanInput("createGithubReleases"),
       });
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -51,6 +51,7 @@ const createRelease = async (
 type PublishOptions = {
   script: string;
   githubToken: string;
+  pushGitTags: boolean;
   createGithubReleases: boolean;
   cwd?: string;
 };
@@ -69,6 +70,7 @@ type PublishResult =
 export async function runPublish({
   script,
   githubToken,
+  pushGitTags,
   createGithubReleases,
   cwd = process.cwd(),
 }: PublishOptions): Promise<PublishResult> {
@@ -81,7 +83,9 @@ export async function runPublish({
     { cwd }
   );
 
-  await gitUtils.pushTags();
+  if (pushGitTags) {
+    await gitUtils.pushTags();
+  }
 
   let { packages, tool } = await getPackages(cwd);
   let releasedPackages: Package[] = [];


### PR DESCRIPTION
Workaround for #141 to disable pushing tags to Github