### PR TITLE
Add `concurrency` option to the exampels in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ on:
     branches:
       - master
 
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   release:
     name: Release
@@ -68,6 +70,8 @@ on:
   push:
     branches:
       - master
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   release:
@@ -137,6 +141,8 @@ on:
   push:
     branches:
       - master
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   release:


### PR DESCRIPTION
This should limit possible race conditions as only a single run of a workflow can be active at any given moment thanks to this setting:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency