### PR TITLE
fix: github PR body max length

### DIFF
--- a/.changeset/lucky-pans-thank.md
+++ b/.changeset/lucky-pans-thank.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": patch
+---
+
+Truncate GitHub PR message if it exceeds a size limit of 60k characters.

--- a/.changeset/lucky-pans-thank.md
+++ b/.changeset/lucky-pans-thank.md
@@ -2,4 +2,4 @@
 "@changesets/action": patch
 ---
 
-Truncate GitHub PR message if it exceeds a size limit of 60k characters.
+Automatically adjust GitHub PR message if it exceeds a size limit of 60k characters by omitting some of the changelog information.

--- a/src/__snapshots__/run.test.ts.snap
+++ b/src/__snapshots__/run.test.ts.snap
@@ -33,7 +33,7 @@ Array [
 ]
 `;
 
-exports[`version does not include any release information if message exceeds size limit 1`] = `
+exports[`version does not include any release information if a message with simplified release info exceeds size limit 1`] = `
 Array [
   Object {
     "base": "some-branch",
@@ -51,7 +51,7 @@ Array [
 ]
 `;
 
-exports[`version does not include changelog entry if message exceeds size limit 1`] = `
+exports[`version does not include changelog entries if full message exceeds size limit 1`] = `
 Array [
   Object {
     "base": "some-branch",

--- a/src/__snapshots__/run.test.ts.snap
+++ b/src/__snapshots__/run.test.ts.snap
@@ -6,6 +6,7 @@ Array [
     "base": "some-branch",
     "body": "This PR was opened by the [Changesets release](https://github.com/changesets/action) GitHub action. When you're ready to do a release, you can merge this and publish to npm yourself or [setup this action to publish automatically](https://github.com/changesets/action#with-publishing). If you're not ready to do a release yet, that's fine, whenever you add more changesets to some-branch, this PR will be updated.
 
+
 # Releases
 ## simple-project-pkg-a@1.1.0
 
@@ -18,11 +19,51 @@ Array [
 -   Updated dependencies
     -   simple-project-pkg-b@1.1.0
 
- ## simple-project-pkg-b@1.1.0
+## simple-project-pkg-b@1.1.0
 
 ### Minor Changes
 
 -   Awesome feature
+",
+    "head": "changeset-release/some-branch",
+    "owner": "changesets",
+    "repo": "action",
+    "title": "Version Packages",
+  },
+]
+`;
+
+exports[`version does not include any release information if message exceeds size limit 1`] = `
+Array [
+  Object {
+    "base": "some-branch",
+    "body": "This PR was opened by the [Changesets release](https://github.com/changesets/action) GitHub action. When you're ready to do a release, you can merge this and publish to npm yourself or [setup this action to publish automatically](https://github.com/changesets/action#with-publishing). If you're not ready to do a release yet, that's fine, whenever you add more changesets to some-branch, this PR will be updated.
+
+
+# Releases
+
+> All release information have been omitted from this message, as the content exceeds the size limit.",
+    "head": "changeset-release/some-branch",
+    "owner": "changesets",
+    "repo": "action",
+    "title": "Version Packages",
+  },
+]
+`;
+
+exports[`version does not include changelog entry if message exceeds size limit 1`] = `
+Array [
+  Object {
+    "base": "some-branch",
+    "body": "This PR was opened by the [Changesets release](https://github.com/changesets/action) GitHub action. When you're ready to do a release, you can merge this and publish to npm yourself or [setup this action to publish automatically](https://github.com/changesets/action#with-publishing). If you're not ready to do a release yet, that's fine, whenever you add more changesets to some-branch, this PR will be updated.
+
+
+# Releases
+
+> The changelog information of each package has been omitted from this message, as the content exceeds the size limit.
+
+## simple-project-pkg-a@1.1.0
+
 ",
     "head": "changeset-release/some-branch",
     "owner": "changesets",
@@ -37,6 +78,7 @@ Array [
   Object {
     "base": "some-branch",
     "body": "This PR was opened by the [Changesets release](https://github.com/changesets/action) GitHub action. When you're ready to do a release, you can merge this and publish to npm yourself or [setup this action to publish automatically](https://github.com/changesets/action#with-publishing). If you're not ready to do a release yet, that's fine, whenever you add more changesets to some-branch, this PR will be updated.
+
 
 # Releases
 ## ignored-package-pkg-b@1.1.0
@@ -58,6 +100,7 @@ Array [
   Object {
     "base": "some-branch",
     "body": "This PR was opened by the [Changesets release](https://github.com/changesets/action) GitHub action. When you're ready to do a release, you can merge this and publish to npm yourself or [setup this action to publish automatically](https://github.com/changesets/action#with-publishing). If you're not ready to do a release yet, that's fine, whenever you add more changesets to some-branch, this PR will be updated.
+
 
 # Releases
 ## simple-project-pkg-a@1.1.0

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -157,4 +157,114 @@ describe("version", () => {
 
     expect(mockedGithubMethods.pulls.create.mock.calls[0]).toMatchSnapshot();
   });
+
+  it("does not include changelog entry if message exceeds size limit", async () => {
+    let cwd = f.copy("simple-project");
+    linkNodeModules(cwd);
+
+    mockedGithubMethods.search.issuesAndPullRequests.mockImplementationOnce(
+      () => ({ data: { items: [] } })
+    );
+
+    await writeChangesets(
+      [
+        {
+          releases: [
+            {
+              name: "simple-project-pkg-a",
+              type: "minor",
+            },
+          ],
+          summary: `# Non manus superum
+
+## Nec cornibus aequa numinis multo onerosior adde
+
+Lorem markdownum undas consumpserat malas, nec est lupus; memorant gentisque ab
+limine auctore. Eatque et promptu deficit, quam videtur aequa est **faciat**,
+locus. Potentia deus habebat pia quam qui coniuge frater, tibi habent fertque
+viribus. E et cognoscere arcus, lacus aut sic pro crimina fuit tum **auxilium**
+dictis, qua, in.
+
+In modo. Nomen illa membra.
+
+> Corpora gratissima parens montibus tum coeperat qua remulus caelum Helenamque?
+> Non poenae modulatur Amathunta in concita superi, procerum pariter rapto cornu
+> munera. Perrhaebum parvo manus contingere, morari, spes per totiens ut
+> dividite proculcat facit, visa.
+
+Adspicit sequitur diffamatamque superi Phoebo qua quin lammina utque: per? Exit
+decus aut hac inpia, seducta mirantia extremo. Vidi pedes vetus. Saturnius
+fluminis divesque vulnere aquis parce lapsis rabie si visa fulmineis.
+`,
+        },
+      ],
+      cwd
+    );
+
+    await runVersion({
+      githubToken: "@@GITHUB_TOKEN",
+      cwd,
+      maxCharactersPerMessage: 1000,
+    });
+
+    expect(mockedGithubMethods.pulls.create.mock.calls[0]).toMatchSnapshot();
+    expect(mockedGithubMethods.pulls.create.mock.calls[0][0].body).toMatch(
+      /The changelog information of each package has been omitted from this message/
+    );
+  });
+
+  it("does not include any release information if message exceeds size limit", async () => {
+    let cwd = f.copy("simple-project");
+    linkNodeModules(cwd);
+
+    mockedGithubMethods.search.issuesAndPullRequests.mockImplementationOnce(
+      () => ({ data: { items: [] } })
+    );
+
+    await writeChangesets(
+      [
+        {
+          releases: [
+            {
+              name: "simple-project-pkg-a",
+              type: "minor",
+            },
+          ],
+          summary: `# Non manus superum
+
+## Nec cornibus aequa numinis multo onerosior adde
+
+Lorem markdownum undas consumpserat malas, nec est lupus; memorant gentisque ab
+limine auctore. Eatque et promptu deficit, quam videtur aequa est **faciat**,
+locus. Potentia deus habebat pia quam qui coniuge frater, tibi habent fertque
+viribus. E et cognoscere arcus, lacus aut sic pro crimina fuit tum **auxilium**
+dictis, qua, in.
+
+In modo. Nomen illa membra.
+
+> Corpora gratissima parens montibus tum coeperat qua remulus caelum Helenamque?
+> Non poenae modulatur Amathunta in concita superi, procerum pariter rapto cornu
+> munera. Perrhaebum parvo manus contingere, morari, spes per totiens ut
+> dividite proculcat facit, visa.
+
+Adspicit sequitur diffamatamque superi Phoebo qua quin lammina utque: per? Exit
+decus aut hac inpia, seducta mirantia extremo. Vidi pedes vetus. Saturnius
+fluminis divesque vulnere aquis parce lapsis rabie si visa fulmineis.
+`,
+        },
+      ],
+      cwd
+    );
+
+    await runVersion({
+      githubToken: "@@GITHUB_TOKEN",
+      cwd,
+      maxCharactersPerMessage: 500,
+    });
+
+    expect(mockedGithubMethods.pulls.create.mock.calls[0]).toMatchSnapshot();
+    expect(mockedGithubMethods.pulls.create.mock.calls[0][0].body).toMatch(
+      /All release information have been omitted from this message, as the content exceeds the size limit/
+    );
+  });
 });

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -158,7 +158,7 @@ describe("version", () => {
     expect(mockedGithubMethods.pulls.create.mock.calls[0]).toMatchSnapshot();
   });
 
-  it("does not include changelog entry if message exceeds size limit", async () => {
+  it("does not include changelog entries if full message exceeds size limit", async () => {
     let cwd = f.copy("simple-project");
     linkNodeModules(cwd);
 
@@ -213,7 +213,7 @@ fluminis divesque vulnere aquis parce lapsis rabie si visa fulmineis.
     );
   });
 
-  it("does not include any release information if message exceeds size limit", async () => {
+  it("does not include any release information if a message with simplified release info exceeds size limit", async () => {
     let cwd = f.copy("simple-project");
     linkNodeModules(cwd);
 

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -57,9 +57,9 @@ describe("version", () => {
       () => ({ data: { items: [] } })
     );
 
-    mockedGithubMethods.pulls.create.mockImplementationOnce(
-      () => ({ data: { number: 123 } })
-    );
+    mockedGithubMethods.pulls.create.mockImplementationOnce(() => ({
+      data: { number: 123 },
+    }));
 
     await writeChangesets(
       [
@@ -96,9 +96,9 @@ describe("version", () => {
       () => ({ data: { items: [] } })
     );
 
-    mockedGithubMethods.pulls.create.mockImplementationOnce(
-      () => ({ data: { number: 123 } })
-    );
+    mockedGithubMethods.pulls.create.mockImplementationOnce(() => ({
+      data: { number: 123 },
+    }));
 
     await writeChangesets(
       [
@@ -131,9 +131,9 @@ describe("version", () => {
       () => ({ data: { items: [] } })
     );
 
-    mockedGithubMethods.pulls.create.mockImplementationOnce(
-      () => ({ data: { number: 123 } })
-    );
+    mockedGithubMethods.pulls.create.mockImplementationOnce(() => ({
+      data: { number: 123 },
+    }));
 
     await writeChangesets(
       [
@@ -166,6 +166,10 @@ describe("version", () => {
       () => ({ data: { items: [] } })
     );
 
+    mockedGithubMethods.pulls.create.mockImplementationOnce(() => ({
+      data: { number: 123 },
+    }));
+
     await writeChangesets(
       [
         {
@@ -204,7 +208,7 @@ fluminis divesque vulnere aquis parce lapsis rabie si visa fulmineis.
     await runVersion({
       githubToken: "@@GITHUB_TOKEN",
       cwd,
-      maxCharactersPerMessage: 1000,
+      prBodyMaxCharacters: 1000,
     });
 
     expect(mockedGithubMethods.pulls.create.mock.calls[0]).toMatchSnapshot();
@@ -221,6 +225,10 @@ fluminis divesque vulnere aquis parce lapsis rabie si visa fulmineis.
       () => ({ data: { items: [] } })
     );
 
+    mockedGithubMethods.pulls.create.mockImplementationOnce(() => ({
+      data: { number: 123 },
+    }));
+
     await writeChangesets(
       [
         {
@@ -259,7 +267,7 @@ fluminis divesque vulnere aquis parce lapsis rabie si visa fulmineis.
     await runVersion({
       githubToken: "@@GITHUB_TOKEN",
       cwd,
-      maxCharactersPerMessage: 500,
+      prBodyMaxCharacters: 500,
     });
 
     expect(mockedGithubMethods.pulls.create.mock.calls[0]).toMatchSnapshot();

--- a/src/run.ts
+++ b/src/run.ts
@@ -47,7 +47,7 @@ const createRelease = async (
       prerelease: pkg.packageJson.version.includes("-"),
       ...github.context.repo,
     });
-  } catch (err) {
+  } catch (err: any) {
     // if we can't find a changelog, the user has probably disabled changelogs
     if (err.code !== "ENOENT") {
       throw err;

--- a/src/run.ts
+++ b/src/run.ts
@@ -165,8 +165,7 @@ export async function runPublish({
 const requireChangesetsCliPkgJson = (cwd: string) => {
   try {
     return require(resolveFrom(cwd, "@changesets/cli/package.json"));
-  } catch (err) {
-    // @ts-ignore
+  } catch (err: any) {
     if (err && err.code === "MODULE_NOT_FOUND") {
       throw new Error(
         `Have you forgotten to install \`@changesets/cli\` in "${cwd}"?`
@@ -357,7 +356,7 @@ export async function runVersion({
   } else {
     const [pullRequest] = searchResult.data.items;
 
-    console.log("pull request found, updating");
+    console.log(`updating found pull request #${pullRequest.number}`);
     await octokit.pulls.update({
       pull_number: pullRequest.number,
       title: finalPrTitle,

--- a/src/run.ts
+++ b/src/run.ts
@@ -291,6 +291,9 @@ ${
 
   let messageBody = await prBodyPromise;
   if (messageBody.length > MAX_CHARACTERS_PER_MESSAGE) {
+    console.log(
+      `message body too long, truncating at ${MAX_CHARACTERS_PER_MESSAGE} charachters.`
+    );
     messageBody = [
       messageBody.substring(0, MAX_CHARACTERS_PER_MESSAGE),
       "[Too long, message truncated]",
@@ -298,9 +301,7 @@ ${
   }
   if (searchResult.data.items.length === 0) {
     console.log("creating pull request");
-    const {
-      data: { number },
-    } = await octokit.pulls.create({
+    const { data: newPullRequest } = await octokit.pulls.create({
       base: branch,
       head: versionBranch,
       title: finalPrTitle,
@@ -309,19 +310,21 @@ ${
     });
 
     return {
-      pullRequestNumber: number,
+      pullRequestNumber: newPullRequest.number,
     };
   } else {
+    const [pullRequest] = searchResult.data.items;
+
+    console.log("pull request found, updating");
     await octokit.pulls.update({
-      pull_number: searchResult.data.items[0].number,
+      pull_number: pullRequest.number,
       title: finalPrTitle,
       body: messageBody,
       ...github.context.repo,
     });
-    console.log("pull request found");
 
     return {
-      pullRequestNumber: searchResult.data.items[0].number,
+      pullRequestNumber: pullRequest.number,
     };
   }
 }


### PR DESCRIPTION
I had an issue today where the PR body exceeded a size limit.

<img width="745" alt="image" src="https://user-images.githubusercontent.com/1110551/156744874-6ee4bf4c-8083-4ee3-865e-92f2834a3de2.png">

This prevents the PR to be created.

To fix that we can truncate the message if we detect it's too long.

Let me know what you think and if I need to add a test for this use case.

This is how the truncated message in the PR looks like:

<img width="384" alt="image" src="https://user-images.githubusercontent.com/1110551/156745382-65092f1d-a637-48ee-a39a-c6dc7aefc1d4.png">
