### PR TITLE
Change directory to `cwd` before running git user setup.

### DIFF
--- a/.changeset/old-socks-unite.md
+++ b/.changeset/old-socks-unite.md
@@ -2,4 +2,4 @@
 "@changesets/action": patch
 ---
 
-Change directory to `cwd` before running git user setup.
+Change directory to `cwd` before running git user setup. This fixes an issue when the action starts its execution not in a git repository.

--- a/.changeset/old-socks-unite.md
+++ b/.changeset/old-socks-unite.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": patch
+---
+
+Change directory to `cwd` before running git user setup.

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,12 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
     return;
   }
 
+  const inputCwd = core.getInput("cwd");
+  if (inputCwd) {
+    console.log("changing directory to the one given as the input");
+    process.chdir(inputCwd);
+  }
+
   let setupGitUser = core.getBooleanInput("setupGitUser");
 
   if (setupGitUser) {
@@ -26,12 +32,6 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
     `${process.env.HOME}/.netrc`,
     `machine github.com\nlogin github-actions[bot]\npassword ${githubToken}`
   );
-
-  const inputCwd = core.getInput("cwd");
-  if (inputCwd) {
-    console.log("changing directory to the one given as the input");
-    process.chdir(inputCwd);
-  }
 
   let { changesets } = await readChangesetState();
 


### PR DESCRIPTION
This PR applies `cwd` before setting the git user name and email. Without this change, the git setup commands are run in `$GITHUB_WORKSPACE`, which will fail if `$GITHUB_WORKSPACE` is not a git repo.

Fixes https://github.com/changesets/action/issues/159.