### PR TITLE
feat: include changed packages when release PR created or updated

### DIFF
--- a/.changeset/nasty-clocks-dream.md
+++ b/.changeset/nasty-clocks-dream.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": minor
+---
+
+include changed packages when release PR created or updated

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This action for [Changesets](https://github.com/atlassian/changesets) creates a 
 
 - published - A boolean value to indicate whether a publishing is happened or not
 - publishedPackages - A JSON array to present the published packages. The format is `[{"name": "@xx/xx", "version": "1.2.0"}, {"name": "@xx/xy", "version": "0.8.9"}]`
-- changedPackages - A JSON array to present the changed packages that are ready to publish. Note, this array is available when Pull Request for the release has been either created or updated The format is `[{"name": "@xx/xx", "version": "1.2.0"}, {"name": "@xx/xy", "version": "0.8.9"}]`
+- versionedPackages - A JSON array to present the versioned packages that are ready to publish. Note, this array is available when Pull Request for the release has been either created or updated The format is `[{"name": "@xx/xx", "version": "1.2.0"}, {"name": "@xx/xy", "version": "0.8.9"}]`
 
 ### Example workflow:
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This action for [Changesets](https://github.com/atlassian/changesets) creates a 
 
 - published - A boolean value to indicate whether a publishing is happened or not
 - publishedPackages - A JSON array to present the published packages. The format is `[{"name": "@xx/xx", "version": "1.2.0"}, {"name": "@xx/xy", "version": "0.8.9"}]`
+- changedPackages - A JSON array to present the changed packages that are ready to publish. Note, this array is available when Pull Request for the release has been either created or updated The format is `[{"name": "@xx/xx", "version": "1.2.0"}, {"name": "@xx/xy", "version": "0.8.9"}]`
 
 ### Example workflow:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,13 +97,19 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
       return;
     }
     case hasChangesets:
-      await runVersion({
+      const result = await runVersion({
         script: getOptionalInput("version"),
         githubToken,
         prTitle: getOptionalInput("title"),
         commitMessage: getOptionalInput("commit"),
         hasPublishScript,
       });
+
+      core.setOutput(
+        "changedPackages",
+        JSON.stringify(result.changedPackages)
+      );
+
       return;
   }
 })().catch((err) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,8 +106,8 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
       });
 
       core.setOutput(
-        "changedPackages",
-        JSON.stringify(result.changedPackages)
+        "versionedPackages",
+        JSON.stringify(result.versionedPackages)
       );
 
       return;

--- a/src/run.ts
+++ b/src/run.ts
@@ -296,4 +296,11 @@ ${
     });
     console.log("pull request found");
   }
+
+  return {
+    changedPackages: changedPackages.map((p) => ({
+      name: p.packageJson.name,
+      version: p.packageJson.version,
+    })),
+  };
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -298,9 +298,9 @@ ${
   }
 
   return {
-    changedPackages: changedPackages.map((p) => ({
-      name: p.packageJson.name,
-      version: p.packageJson.version,
+    versionedPackages: changedPackages.map((pkg) => ({
+      name: pkg.packageJson.name,
+      version: pkg.packageJson.version,
     })),
   };
 }


### PR DESCRIPTION
This feature allows `changesets/action` users to get changed packages as output. This is useful to have this output not only for `publishedPackages` when `publish` occurred but also when  for example `prerelease` has been completed.