### PR TITLE
Add Optional skipNpmrc input

### DIFF
--- a/.changeset/tricky-impalas-protect.md
+++ b/.changeset/tricky-impalas-protect.md
@@ -1,0 +1,6 @@
+---
+"@changesets/action": minor
+---
+
+Added option to ignore creation or modification of `.npmrc` file.
+This resolves issues where the correctly configured `.npmrc` file does not match the assumptions made by the action, such as when authenticating to Azure DevOps Artifact Feeds.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This action for [Changesets](https://github.com/atlassian/changesets) creates a 
 - title - The pull request title. Default to `Version Packages`
 - setupGitUser - Sets up the git user for commits as `"github-actions[bot]"`. Default to `true`
 - cwd - Changes node's `process.cwd()` if the project is not located on the root. Default to `process.cwd()`
+- skipNpmrc - Skips the creation or update of the `.npmrc` file. Only set to `true` if registry authentication is already handled. Defaults to `false`.
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: "A boolean value to indicate whether to create Github releases after `publish` or not"
     required: false
     default: true
+  skipNpmrc:
+    description: "A boolean value to indicate whether to skip the `npmrc` file creation/modification or not"
+    required: false
+    default: false
 outputs:
   published:
     description: A boolean value to indicate whether a publishing is happened or not

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,33 +52,8 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
         "No changesets found, attempting to publish any unpublished packages to npm"
       );
 
-      let userNpmrcPath = `${process.env.HOME}/.npmrc`;
-      if (fs.existsSync(userNpmrcPath)) {
-        console.log("Found existing user .npmrc file");
-        const userNpmrcContent = await fs.readFile(userNpmrcPath, "utf8");
-        const authLine = userNpmrcContent.split("\n").find((line) => {
-          // check based on https://github.com/npm/cli/blob/8f8f71e4dd5ee66b3b17888faad5a7bf6c657eed/test/lib/adduser.js#L103-L105
-          return /^\s*\/\/registry\.npmjs\.org\/:[_-]authToken=/i.test(line);
-        });
-        if (authLine) {
-          console.log(
-            "Found existing auth token for the npm registry in the user .npmrc file"
-          );
-        } else {
-          console.log(
-            "Didn't find existing auth token for the npm registry in the user .npmrc file, creating one"
-          );
-          fs.appendFileSync(
-            userNpmrcPath,
-            `\n//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}\n`
-          );
-        }
-      } else {
-        console.log("No user .npmrc file found, creating one");
-        fs.writeFileSync(
-          userNpmrcPath,
-          `//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}\n`
-        );
+      if (!core.getBooleanInput("skipNpmrc")) {
+        await createOrUpdateNpmrc();
       }
 
       const result = await runPublish({
@@ -113,3 +88,35 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
   console.error(err);
   core.setFailed(err.message);
 });
+
+
+async function createOrUpdateNpmrc() {
+  let userNpmrcPath = `${process.env.HOME}/.npmrc`;
+  if (fs.existsSync(userNpmrcPath)) {
+    console.log("Found existing user .npmrc file");
+    const userNpmrcContent = await fs.readFile(userNpmrcPath, "utf8");
+    const authLine = userNpmrcContent.split("\n").find((line) => {
+      // check based on https://github.com/npm/cli/blob/8f8f71e4dd5ee66b3b17888faad5a7bf6c657eed/test/lib/adduser.js#L103-L105
+      return /^\s*\/\/registry\.npmjs\.org\/:[_-]authToken=/i.test(line);
+    });
+    if (authLine) {
+      console.log(
+        "Found existing auth token for the npm registry in the user .npmrc file"
+      );
+    } else {
+      console.log(
+        "Didn't find existing auth token for the npm registry in the user .npmrc file, creating one"
+      );
+      fs.appendFileSync(
+        userNpmrcPath,
+        `\n//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}\n`
+      );
+    }
+  } else {
+    console.log("No user .npmrc file found, creating one");
+    fs.writeFileSync(
+      userNpmrcPath,
+      `//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}\n`
+    );
+  }
+}


### PR DESCRIPTION
As part of trying to use this action for a private Azure DevOps Artifact Feed (where the `.npmrc` file uses `username` and `_password` instead of `_authToken`), I ran into the issue where the file was always modified by the action.

This PR adds an optional input called `skipNpmrc` which simply bypasses any checks, creation, or update of the `.npmrc` file.  Not including the new input continues to behave exactly as it does today.

None of the code in the new `createOrUpdateNpmrc` function was modified, just extracted into the function.

While I am unblocked since I am running the action successfully now from the fork, I thought this might be generally useful if others have the same problem.  If this is not in line with your vision of the action, please feel free to close.  No hard feelings.  😄 