### PR TITLE
Fixed PR message when pre schema operations exist in custom version script

### DIFF
--- a/.changeset/eleven-kings-remember.md
+++ b/.changeset/eleven-kings-remember.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": patch
+---
+
+Fixed PR message when pre schema operations exist in custom version script

--- a/src/run.ts
+++ b/src/run.ts
@@ -193,7 +193,6 @@ export async function runVersion({
   let branch = github.context.ref.replace("refs/heads/", "");
   let versionBranch = `changeset-release/${branch}`;
   let octokit = github.getOctokit(githubToken);
-  let { preState } = await readChangesetState(cwd);
 
   await gitUtils.switchToMaybeExistingBranch(versionBranch);
   await gitUtils.reset(github.context.sha);
@@ -213,6 +212,7 @@ export async function runVersion({
     });
   }
 
+  let { preState } = await readChangesetState(cwd);
   let searchQuery = `repo:${repo}+state:open+head:${versionBranch}+base:${branch}`;
   let searchResultPromise = octokit.search.issuesAndPullRequests({
     q: searchQuery,


### PR DESCRIPTION
Let custom version script support to modify the prerelease mode.

