### PR TITLE
Remove suggestions of using `fetch-depth: 0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-        with:
-          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
-          fetch-depth: 0
 
       - name: Setup Node.js 12.x
         uses: actions/setup-node@v2
@@ -80,9 +77,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-        with:
-          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
-          fetch-depth: 0
 
       - name: Setup Node.js 12.x
         uses: actions/setup-node@v2
@@ -149,9 +143,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-        with:
-          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
-          fetch-depth: 0
 
       - name: Setup Node.js 12.x
         uses: actions/setup-node@v2
@@ -196,8 +187,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       - name: Setup Node.js 12.x
         uses: actions/setup-node@v2


### PR DESCRIPTION
Changesets automatically deepens a shallow clone as necessary,
so we don't need to recommend a complete deep clone in order
for changesets to work.

Fixes: #97