### PR TITLE
feat: add `labels` input to configure

### DIFF
--- a/.changeset/slow-actors-exercise.md
+++ b/.changeset/slow-actors-exercise.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": minor
+---
+
+Add `labels` input to configure

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,9 @@ inputs:
     description: "A boolean value to indicate whether to create Github releases after `publish` or not"
     required: false
     default: true
+  labels:
+    description: The pull request labels that comma separated. Default is empty
+    required: false
 outputs:
   published:
     description: A boolean value to indicate whether a publishing is happened or not

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,6 +101,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
         script: getOptionalInput("version"),
         githubToken,
         prTitle: getOptionalInput("title"),
+        prLabels: (getOptionalInput("labels") ?? "").split(","),
         commitMessage: getOptionalInput("commit"),
         hasPublishScript,
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
         script: getOptionalInput("version"),
         githubToken,
         prTitle: getOptionalInput("title"),
-        prLabels: (getOptionalInput("labels") ?? "").split(","),
+        prLabels: (getOptionalInput("labels") || "").split(","),
         commitMessage: getOptionalInput("commit"),
         hasPublishScript,
       });

--- a/src/run.ts
+++ b/src/run.ts
@@ -249,6 +249,7 @@ type VersionOptions = {
   githubToken: string;
   cwd?: string;
   prTitle?: string;
+  prLabels?: string[];
   commitMessage?: string;
   hasPublishScript?: boolean;
   prBodyMaxCharacters?: number;
@@ -263,6 +264,7 @@ export async function runVersion({
   githubToken,
   cwd = process.cwd(),
   prTitle = "Version Packages",
+  prLabels = [],
   commitMessage = "Version Packages",
   hasPublishScript = false,
   prBodyMaxCharacters = MAX_CHARACTERS_PER_MESSAGE,
@@ -350,6 +352,15 @@ export async function runVersion({
       ...github.context.repo,
     });
 
+    if (prLabels.length > 0) {
+      console.log("adding labels to the pull request");
+      await octokit.issues.addLabels({
+        issue_number: newPullRequest.number,
+        labels: prLabels,
+        ...github.context.repo,
+      });
+    }
+
     return {
       pullRequestNumber: newPullRequest.number,
     };
@@ -363,6 +374,18 @@ export async function runVersion({
       body: prBody,
       ...github.context.repo,
     });
+
+    if (prLabels.length > 0) {
+      const existingLabels = pullRequest.labels.map((l) => l.name);
+      if (prLabels.some((l) => !existingLabels.includes(l))) {
+        console.log("adding labels to the pull request");
+        await octokit.issues.addLabels({
+          issue_number: pullRequest.number,
+          labels: prLabels,
+          ...github.context.repo,
+        });
+      }
+    }
 
     return {
       pullRequestNumber: pullRequest.number,


### PR DESCRIPTION
It would be cool to attach labels when the action creates a release PR.
For example, if we add a `release` label to PRs, we can find release PRs easily. 

I implemented `labels` input.
`labels` allows input, and we can specify comma-separated labels(include space).

e.g.
```yml
      - name: Create Release Pull Request
        uses: notfounds/changesets-action@main
        with:
          publish: yarn changeset publish
          labels: "release,test label,test-label2"
``` 
cf. https://github.com/NotFounds/changesets-monorepo/blob/d42f07d8b7def90913c71be14e9d69c8d3254876/.github/workflows/release.yml

I confirmed it works well in https://github.com/NotFounds/changesets-monorepo/pull/5.
