### PR TITLE
remove unnecessary config from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ For example, you can add a step before running the Changesets GitHub Action:
 - name: Creating .npmrc
   run: |
     cat << EOF > "$HOME/.npmrc"
-      email=my@email.com
       //registry.npmjs.org/:_authToken=$NPM_TOKEN
     EOF
   env:


### PR DESCRIPTION
The `email=my@email.com` line isn't necessary. It doesn't seem to be a real configuration option and as far as I can tell npm ignores it. 

fixes #185