### PR TITLE
Support "aggregate" mode in `createGithubReleases` config flag

### DIFF
--- a/.changeset/spicy-toes-confess.md
+++ b/.changeset/spicy-toes-confess.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": minor
+---
+
+Allow to specify `createGithubReleases: aggregate`, in order to publish a single GitHub Release

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This action for [Changesets](https://github.com/atlassian/changesets) creates a 
 - commit - The commit message to use. Default to `Version Packages`
 - title - The pull request title. Default to `Version Packages`
 - setupGitUser - Sets up the git user for commits as `"github-actions[bot]"`. Default to `true`
-- createGithubReleases - A boolean value to indicate whether to create Github releases after `publish` or not. Default to `true`
+- createGithubReleases - A boolean/string value to indicate whether to create Github releases after `publish` or not. Default to `"true"`. Set to `aggregate` if you wish to group all published releases into a single GitHub Release.
 - cwd - Changes node's `process.cwd()` if the project is not located on the root. Default to `process.cwd()`
 
 ### Outputs

--- a/__fixtures__/simple-project-published/.changeset/config.json
+++ b/__fixtures__/simple-project-published/.changeset/config.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@1.3.0/schema.json"
+}

--- a/__fixtures__/simple-project-published/package.json
+++ b/__fixtures__/simple-project-published/package.json
@@ -1,0 +1,11 @@
+{
+  "private": true,
+  "name": "simple-project",
+  "version": "1.0.0",
+  "scripts": {
+    "release": "changeset publish" 
+  },
+  "workspaces": [
+    "packages/*"
+  ]
+}

--- a/__fixtures__/simple-project-published/packages/pkg-a/CHANGELOG.md
+++ b/__fixtures__/simple-project-published/packages/pkg-a/CHANGELOG.md
@@ -1,0 +1,7 @@
+# simple-project-pkg-a
+
+## 0.0.1
+
+### Patch Changes
+
+- 1e3d37a34: change something in a

--- a/__fixtures__/simple-project-published/packages/pkg-a/package.json
+++ b/__fixtures__/simple-project-published/packages/pkg-a/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "simple-project-pkg-a",
+  "version": "0.0.1",
+  "dependencies": {
+    "simple-project-pkg-b": "0.0.1"
+  }
+}

--- a/__fixtures__/simple-project-published/packages/pkg-b/CHANGELOG.md
+++ b/__fixtures__/simple-project-published/packages/pkg-b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# simple-project-pkg-b
+
+## 0.0.1
+
+### Patch Changes
+
+- 1e3d37a34: change something in b

--- a/__fixtures__/simple-project-published/packages/pkg-b/package.json
+++ b/__fixtures__/simple-project-published/packages/pkg-b/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "simple-project-pkg-b",
+  "version": "0.0.1"
+}

--- a/action.yml
+++ b/action.yml
@@ -25,9 +25,9 @@ inputs:
     required: false
     default: true
   createGithubReleases:
-    description: "A boolean value to indicate whether to create Github releases after `publish` or not"
+    description: "A value to indicate whether to create Github releases after `publish` or not, and on which mode"
     required: false
-    default: true
+    default: 'true'
 outputs:
   published:
     description: A boolean value to indicate whether a publishing is happened or not

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,26 @@
 import * as core from "@actions/core";
 import fs from "fs-extra";
 import * as gitUtils from "./gitUtils";
-import { runPublish, runVersion } from "./run";
+import { PublishOptions, runPublish, runVersion } from "./run";
 import readChangesetState from "./readChangesetState";
 
 const getOptionalInput = (name: string) => core.getInput(name) || undefined;
+
+function extractCreateGithubReleases(
+  input: string
+): PublishOptions["createGithubReleases"] {
+  if (input === "aggregate") {
+    return "aggregate";
+  } else if (input === "true") {
+    return true;
+  }
+
+  core.warning(
+    `Invalid value for createGithubReleases: ${input}, assuming "false"...`
+  );
+
+  return false;
+}
 
 (async () => {
   let githubToken = process.env.GITHUB_TOKEN;
@@ -84,7 +100,9 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
       const result = await runPublish({
         script: publishScript,
         githubToken,
-        createGithubReleases: core.getBooleanInput("createGithubReleases"),
+        createGithubReleases: extractCreateGithubReleases(
+          core.getInput("createGithubReleases")
+        ),
       });
 
       if (result.published) {

--- a/src/run.ts
+++ b/src/run.ts
@@ -44,7 +44,7 @@ const createAggregatedRelease = async (
         );
       }
 
-      return changelogEntry.content;
+      return `## ${pkg.packageJson.name}@${pkg.packageJson.version}\n\n${changelogEntry.content}`;
     })
   );
 


### PR DESCRIPTION
## Background for this PR 

This PR allows users to specify `createGithubReleases: aggregate` in the config, in order to group a Changeset release flow into a single GitHub Release on GitHub. 

This is useful for repositories with many packages and frequent releases, and prevents bloating GitHub Releases page. 

## Actual changes 

- Change `createGithubReleases` config flag to support `true`, `false` or `aggregate` mode. 
- Added support for creating a single GitHub Release for the entire Changeset publish command.
- Added unit tests for the `publish` flow and a fixture matching the requirements

## Related issues

- Closes https://github.com/changesets/changesets/issues/683
- Closes https://github.com/changesets/changesets/issues/387
- Closes https://github.com/changesets/changesets/issues/320
- Related https://github.com/changesets/changesets/issues/264
- Related https://github.com/changesets/changesets/issues/655