### PR TITLE
Change push command option to use --follow-tags instead of --tags

### DIFF
--- a/.changeset/violet-bags-sell.md
+++ b/.changeset/violet-bags-sell.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": minor
+---
+
+Change git push command option to use '--follow-tags' instead of '--tags'

--- a/src/gitUtils.ts
+++ b/src/gitUtils.ts
@@ -30,8 +30,8 @@ export const push = async (
   );
 };
 
-export const pushTags = async () => {
-  await exec("git", ["push", "origin", "--tags"]);
+export const pushFollowTags = async () => {
+  await exec("git", ["push", "origin", "--follow-tags"]);
 };
 
 export const switchToMaybeExistingBranch = async (branch: string) => {

--- a/src/run.ts
+++ b/src/run.ts
@@ -88,7 +88,7 @@ export async function runPublish({
     { cwd }
   );
 
-  await gitUtils.pushTags();
+  await gitUtils.pushFollowTags();
 
   let { packages, tool } = await getPackages(cwd);
   let releasedPackages: Package[] = [];


### PR DESCRIPTION
There's no necessary to push all tags in `refs/tags`. It's enough to push only lacking tags from the remote. 
So we can use `--follow-tags` option instead of `--tags`.
cf. https://git-scm.com/docs/git-push#Documentation/git-push.txt---follow-tags
> Push all the refs that would be pushed without this option, and also push annotated tags in refs/tags that are missing from the remote but are pointing at commit-ish that are reachable from the refs being pushed.

It can prevent failing workflow with the following exception: `hint: Updates were rejected because the tag already exists in the remote.`