### PR TITLE
Don't create a PR if all changesets are empty

### DIFF
--- a/.changeset/three-needles-protect.md
+++ b/.changeset/three-needles-protect.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": patch
+---
+
+Don't create a PR if all changesets are empty

--- a/.changeset/three-needles-protect.md
+++ b/.changeset/three-needles-protect.md
@@ -2,4 +2,4 @@
 "@changesets/action": patch
 ---
 
-Don't create a PR if all changesets are empty
+Skip creating a PR when all existing changesets are empty.

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,9 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
 
   let publishScript = core.getInput("publish");
   let hasChangesets = changesets.length !== 0;
+  const hasNonEmptyChangesets = changesets.some(
+    (changeset) => changeset.releases.length > 0
+  );
   let hasPublishScript = !!publishScript;
 
   core.setOutput("published", "false");
@@ -96,6 +99,9 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
       }
       return;
     }
+    case hasChangesets && !hasNonEmptyChangesets:
+      console.log("All changesets are empty; not creating PR");
+      return;
     case hasChangesets:
       const { pullRequestNumber } = await runVersion({
         script: getOptionalInput("version"),


### PR DESCRIPTION
Fixes #205.

Note that this maintains the previous behavior that if there are any
changesets (even empty ones), the action does not publish packages.