### PR TITLE
Add `is:pull-request` to search query when looking for existing PR

### DIFF
--- a/.changeset/sharp-pens-matter.md
+++ b/.changeset/sharp-pens-matter.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": patch
+---
+
+Add `is:pull-request` to search query when looking for existing PR

--- a/.changeset/sharp-pens-matter.md
+++ b/.changeset/sharp-pens-matter.md
@@ -2,4 +2,4 @@
 "@changesets/action": patch
 ---
 
-Add `is:pull-request` to search query when looking for existing PR
+Add `is:pull-request` to search query when looking for existing PR. This fixes an issue with user-owned PATs.

--- a/src/run.ts
+++ b/src/run.ts
@@ -291,7 +291,7 @@ export async function runVersion({
     });
   }
 
-  let searchQuery = `repo:${repo}+state:open+head:${versionBranch}+base:${branch}`;
+  let searchQuery = `repo:${repo}+state:open+head:${versionBranch}+base:${branch}+is:pull-request`;
   let searchResultPromise = octokit.search.issuesAndPullRequests({
     q: searchQuery,
   });


### PR DESCRIPTION
Fixes https://github.com/changesets/action/issues/227 by adding the required `is:pull-request` filter to the search query. This will allow users to use user-owned PATs instead of the default `GITHUB_TOKEN`.