### PR TITLE
Use default node version from actions/setup-node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,8 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
-
-      - name: Use Node.js 16
-        uses: actions/setup-node@v1
-        with:
-          node-version: 16.x
+        uses: actions/checkout@v3
+        uses: actions/setup-node@v3
 
       - name: Install Dependencies
         run: yarn --frozen-lockfile

--- a/.github/workflows/version-or-publish.yml
+++ b/.github/workflows/version-or-publish.yml
@@ -12,12 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
-
-      - name: Use Node.js 16
-        uses: actions/setup-node@v1
-        with:
-          node-version: 16.x
+        uses: actions/checkout@v3
+        uses: actions/setup-node@v3
 
       - name: Install Dependencies
         run: yarn --frozen-lockfile

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,6 @@
 name: Changesets
 description: A GitHub action to automate releases with Changesets
 runs:
-  using: "node16"
   main: "dist/index.js"
 inputs:
   publish:


### PR DESCRIPTION
Follow-up to https://github.com/changesets/action/pull/216

The actions/setup-node@v3 uses node16 by default.
The changesets/action can delegate selecting node version, and simplify configuration.

https://github.com/actions/setup-node/blob/6bc15ab23c9584a6fe2fdf1ae07fd5fb409d1dbc/action.yml#L36