### PR TITLE
add support for pr labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This action for [Changesets](https://github.com/atlassian/changesets) creates a 
 - version - The command to update version, edit CHANGELOG, read and delete changesets. Default to `changeset version` if not provided
 - commit - The commit message to use. Default to `Version Packages`
 - title - The pull request title. Default to `Version Packages`
+- labels - The pull request labels. Default to none
 - setupGitUser - Sets up the git user for commits as `"github-actions[bot]"`. Default to `true`
 - createGithubReleases - A boolean value to indicate whether to create Github releases after `publish` or not. Default to `true`
 - cwd - Changes node's `process.cwd()` if the project is not located on the root. Default to `process.cwd()`

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
   title:
     description: The pull request title. Default to `Version Packages`
     required: false
+  labels:
+    description: The pull request labels. Default to none
+    required: false
   setupGitUser:
     description: Sets up the git user for commits as `"github-actions[bot]"`. Default to `true`
     required: false

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
         script: getOptionalInput("version"),
         githubToken,
         prTitle: getOptionalInput("title"),
+        prLabels: getOptionalInput("labels"),
         commitMessage: getOptionalInput("commit"),
         hasPublishScript,
       });

--- a/src/run.ts
+++ b/src/run.ts
@@ -248,6 +248,7 @@ type VersionOptions = {
   githubToken: string;
   cwd?: string;
   prTitle?: string;
+  prLabels?: string;
   commitMessage?: string;
   hasPublishScript?: boolean;
   prBodyMaxCharacters?: number;
@@ -262,6 +263,7 @@ export async function runVersion({
   githubToken,
   cwd = process.cwd(),
   prTitle = "Version Packages",
+  prLabels,
   commitMessage = "Version Packages",
   hasPublishScript = false,
   prBodyMaxCharacters = MAX_CHARACTERS_PER_MESSAGE,
@@ -348,6 +350,14 @@ export async function runVersion({
       body: prBody,
       ...github.context.repo,
     });
+
+    if (prLabels) {
+      await octokit.rest.issues.addLabels({
+        issue_number: newPullRequest.number,
+        labels: [prLabels],
+        ...github.context.repo
+      })
+    }
 
     return {
       pullRequestNumber: newPullRequest.number,


### PR DESCRIPTION
# Context

We would like to attach some labels to the PRs that changesets action opens.

# Changes

- Adding an optional `labels` action options
- Update the created PR with provided labels

# Considerations

- We need to use `issues` rather than `pulls` - however they mean the same thing
- Should we provide a default label? I imagine not
- Should we run `addLabel` when updating a PR as well?