### PR TITLE
unignore dist on main branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,3 @@ node_modules
 .parcel-cache
 .cache
 *.log
-
-dist/


### PR DESCRIPTION
currently the ignore is not needed on the main branch and we are running into a bug with nektos/act which uses the go-git library.

https://github.com/go-git/go-git/issues/633