### PR TITLE
Support publish workflow when ignore option is set

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@babel/core": "^7.13.10",
     "@babel/preset-env": "^7.13.10",
     "@babel/preset-typescript": "^7.13.0",
+    "@changesets/get-release-plan": "^3.0.15",
     "@changesets/pre": "^1.0.9",
     "@changesets/read": "^0.5.3",
     "@manypkg/get-packages": "^1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1713,6 +1713,18 @@
     "@manypkg/get-packages" "^1.1.3"
     semver "^5.4.1"
 
+"@changesets/assemble-release-plan@^5.2.2":
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/@changesets/assemble-release-plan/-/assemble-release-plan-5.2.2.tgz#9824f14a7a6e411c7153f1ccc2a42bbe35688129"
+  integrity sha512-B1qxErQd85AeZgZFZw2bDKyOfdXHhG+X5S+W3Da2yCem8l/pRy4G/S7iOpEcMwg6lH8q2ZhgbZZwZ817D+aLuQ==
+  dependencies:
+    "@babel/runtime" "^7.10.4"
+    "@changesets/errors" "^0.1.4"
+    "@changesets/get-dependents-graph" "^1.3.4"
+    "@changesets/types" "^5.2.0"
+    "@manypkg/get-packages" "^1.1.3"
+    semver "^5.4.1"
+
 "@changesets/changelog-github@^0.4.2":
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/@changesets/changelog-github/-/changelog-github-0.4.2.tgz#359eb4b7485eddc55855f8793811817d5124dfab"
@@ -1771,6 +1783,19 @@
     fs-extra "^7.0.1"
     micromatch "^4.0.2"
 
+"@changesets/config@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@changesets/config/-/config-2.2.0.tgz#382f6cd801fa56273942659114c8060378dfe066"
+  integrity sha512-GGaokp3nm5FEDk/Fv2PCRcQCOxGKKPRZ7prcMqxEr7VSsG75MnChQE8plaW1k6V8L2bJE+jZWiRm19LbnproOw==
+  dependencies:
+    "@changesets/errors" "^0.1.4"
+    "@changesets/get-dependents-graph" "^1.3.4"
+    "@changesets/logger" "^0.0.5"
+    "@changesets/types" "^5.2.0"
+    "@manypkg/get-packages" "^1.1.3"
+    fs-extra "^7.0.1"
+    micromatch "^4.0.2"
+
 "@changesets/errors@^0.1.4":
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/@changesets/errors/-/errors-0.1.4.tgz#f79851746c43679a66b383fdff4c012f480f480d"
@@ -1789,6 +1814,17 @@
     fs-extra "^7.0.1"
     semver "^5.4.1"
 
+"@changesets/get-dependents-graph@^1.3.4":
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/@changesets/get-dependents-graph/-/get-dependents-graph-1.3.4.tgz#d8bf537f45a7ff773da99143675f49e250996838"
+  integrity sha512-+C4AOrrFY146ydrgKOo5vTZfj7vetNu1tWshOID+UjPUU9afYGDXI8yLnAeib1ffeBXV3TuGVcyphKpJ3cKe+A==
+  dependencies:
+    "@changesets/types" "^5.2.0"
+    "@manypkg/get-packages" "^1.1.3"
+    chalk "^2.1.0"
+    fs-extra "^7.0.1"
+    semver "^5.4.1"
+
 "@changesets/get-github-info@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@changesets/get-github-info/-/get-github-info-0.5.0.tgz#b91ceb2d82edef78ae1598ea9fc335a012250295"
@@ -1796,6 +1832,19 @@
   dependencies:
     dataloader "^1.4.0"
     node-fetch "^2.5.0"
+
+"@changesets/get-release-plan@^3.0.15":
+  version "3.0.15"
+  resolved "https://registry.yarnpkg.com/@changesets/get-release-plan/-/get-release-plan-3.0.15.tgz#55577b235b785125a462d5d2a2dffe4dbf94e590"
+  integrity sha512-W1tFwxE178/en+zSj/Nqbc3mvz88mcdqUMJhRzN1jDYqN3QI4ifVaRF9mcWUU+KI0gyYEtYR65tour690PqTcA==
+  dependencies:
+    "@babel/runtime" "^7.10.4"
+    "@changesets/assemble-release-plan" "^5.2.2"
+    "@changesets/config" "^2.2.0"
+    "@changesets/pre" "^1.0.13"
+    "@changesets/read" "^0.5.8"
+    "@changesets/types" "^5.2.0"
+    "@manypkg/get-packages" "^1.1.3"
 
 "@changesets/get-release-plan@^3.0.5":
   version "3.0.5"
@@ -1827,6 +1876,18 @@
     is-subdir "^1.1.1"
     spawndamnit "^2.0.0"
 
+"@changesets/git@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@changesets/git/-/git-1.5.0.tgz#71bbcf11f3b346d56eeaf3d3201e6dc3e270ea5a"
+  integrity sha512-Xo8AT2G7rQJSwV87c8PwMm6BAc98BnufRMsML7m7Iw8Or18WFvFmxqG5aOL5PBvhgq9KrKvaeIBNIymracSuHg==
+  dependencies:
+    "@babel/runtime" "^7.10.4"
+    "@changesets/errors" "^0.1.4"
+    "@changesets/types" "^5.2.0"
+    "@manypkg/get-packages" "^1.1.3"
+    is-subdir "^1.1.1"
+    spawndamnit "^2.0.0"
+
 "@changesets/logger@^0.0.5":
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/@changesets/logger/-/logger-0.0.5.tgz#68305dd5a643e336be16a2369cb17cdd8ed37d4c"
@@ -1841,6 +1902,25 @@
   dependencies:
     "@changesets/types" "^4.0.2"
     js-yaml "^3.13.1"
+
+"@changesets/parse@^0.3.15":
+  version "0.3.15"
+  resolved "https://registry.yarnpkg.com/@changesets/parse/-/parse-0.3.15.tgz#1bc74f8c43b0861d71f4fccf78950411004ba308"
+  integrity sha512-3eDVqVuBtp63i+BxEWHPFj2P1s3syk0PTrk2d94W9JD30iG+OER0Y6n65TeLlY8T2yB9Fvj6Ev5Gg0+cKe/ZUA==
+  dependencies:
+    "@changesets/types" "^5.2.0"
+    js-yaml "^3.13.1"
+
+"@changesets/pre@^1.0.13":
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/@changesets/pre/-/pre-1.0.13.tgz#49c3ae8bb444a1ce3e0fe4cb21f238318b6763e9"
+  integrity sha512-jrZc766+kGZHDukjKhpBXhBJjVQMied4Fu076y9guY1D3H622NOw8AQaLV3oQsDtKBTrT2AUFjt9Z2Y9Qx+GfA==
+  dependencies:
+    "@babel/runtime" "^7.10.4"
+    "@changesets/errors" "^0.1.4"
+    "@changesets/types" "^5.2.0"
+    "@manypkg/get-packages" "^1.1.3"
+    fs-extra "^7.0.1"
 
 "@changesets/pre@^1.0.9":
   version "1.0.9"
@@ -1867,6 +1947,20 @@
     fs-extra "^7.0.1"
     p-filter "^2.1.0"
 
+"@changesets/read@^0.5.8":
+  version "0.5.8"
+  resolved "https://registry.yarnpkg.com/@changesets/read/-/read-0.5.8.tgz#84e24fd12e6759cef090088261c08b1dfe0f350e"
+  integrity sha512-eYaNfxemgX7f7ELC58e7yqQICW5FB7V+bd1lKt7g57mxUrTveYME+JPaBPpYx02nP53XI6CQp6YxnR9NfmFPKw==
+  dependencies:
+    "@babel/runtime" "^7.10.4"
+    "@changesets/git" "^1.5.0"
+    "@changesets/logger" "^0.0.5"
+    "@changesets/parse" "^0.3.15"
+    "@changesets/types" "^5.2.0"
+    chalk "^2.1.0"
+    fs-extra "^7.0.1"
+    p-filter "^2.1.0"
+
 "@changesets/types@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@changesets/types/-/types-4.0.1.tgz#85cf3cc32baff0691112d9d15fc21fbe022c9f0a"
@@ -1876,6 +1970,11 @@
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@changesets/types/-/types-4.0.2.tgz#d20e1e45bdc96a97cc509c655e708b53a9292465"
   integrity sha512-OeDaB7D+WVy/ErymPzFm58IeGvz4DOl+oedyZETfnkfMezF/Uhrm1Ub6MHrO5LcAaQTW+ptDmr0fmaVyoTxgHw==
+
+"@changesets/types@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@changesets/types/-/types-5.2.0.tgz#c4927f5bf9668f778c12b4226cfd07a1f5b79c9b"
+  integrity sha512-km/66KOqJC+eicZXsm2oq8A8bVTSpkZJ60iPV/Nl5Z5c7p9kk8xxh6XGRTlnludHldxOOfudhnDN2qPxtHmXzA==
 
 "@changesets/write@^0.1.6":
   version "0.1.6"


### PR DESCRIPTION
Fixes #241 

The current implementation of using `readChangesetState()` on entry is based on `@changesets/read` which simply reads all of the markdown files in `.changeset` directory.

Trigging the action while using the [`ignore` option](https://github.com/changesets/changesets/blob/main/docs/config-file-options.md#ignore-array-of-packages) with changeset files present for both ignored and non-ignored packages, the `version` will run and consume changesets made for non-ignored packages, but leave those of ignored packages. When the PR is merged and the action is run again in this state, instead of moving on to the `publish` flow, it still enters the `version` flow and tries to make a PR, which fails as there are no releasable packages in this state.

The fix incorporates `@changesets/get-release-plan` which actually returns a list of `releases` which takes into account the ignored packages config. The flow control now utilizes this list to determine whether there's anything to version or publish.

I've done some testing of this change at https://github.com/augustjk/changesets-test-project/actions and confirmed publishing with ignored packages works.

Open questions:
- I've created the variable as `hasReleases` for the control to better reflect this, and added to the output. The `hasChangesets` variable and output no longer really serve a purpose within the code. I've left it here so as not to break users currently using this output as advertised on the README. Is this acceptable?
- I'm unsure whether this should be a minor or patch bump. Leaving the output above should keep this non-breaking, but using the count of `releases` instead of `changesets` might have some other consequences that I'm not thinking of.
