### PR TITLE
Feature: Allow custom PR body

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
         script: getOptionalInput("version"),
         githubToken,
         prTitle: getOptionalInput("title"),
+        prBody: getOptionalInput("body"),
         commitMessage: getOptionalInput("commit"),
         hasPublishScript,
       });

--- a/src/run.ts
+++ b/src/run.ts
@@ -248,6 +248,7 @@ type VersionOptions = {
   githubToken: string;
   cwd?: string;
   prTitle?: string;
+  prBody?: string;
   commitMessage?: string;
   hasPublishScript?: boolean;
   prBodyMaxCharacters?: number;
@@ -262,6 +263,7 @@ export async function runVersion({
   githubToken,
   cwd = process.cwd(),
   prTitle = "Version Packages",
+  prBody,
   commitMessage = "Version Packages",
   hasPublishScript = false,
   prBodyMaxCharacters = MAX_CHARACTERS_PER_MESSAGE,
@@ -331,13 +333,15 @@ export async function runVersion({
     .filter((x) => x)
     .sort(sortTheThings);
 
-  let prBody = await getVersionPrBody({
-    hasPublishScript,
-    preState,
-    branch,
-    changedPackagesInfo,
-    prBodyMaxCharacters,
-  });
+  if (!prBody) {
+    prBody = await getVersionPrBody({
+      hasPublishScript,
+      preState,
+      branch,
+      changedPackagesInfo,
+      prBodyMaxCharacters,
+    });
+  }
 
   if (searchResult.data.items.length === 0) {
     console.log("creating pull request");


### PR DESCRIPTION
Hello,

We're interested in using Changesets in [OpenZeppelin/contracts](https://github.com/OpenZeppelin/openzeppelin-contracts) but unfortunately, we need to post process the changelog, breaking your [getChangelogEntry](https://github.com/changesets/action/blob/595655c3eae7136ff5ba18200406898904362926/src/utils.ts#L38) matching, so we are happy to support our own PR body with this option.

Not sure if this affects other packages, in which case, please let me know.