### PR TITLE
use `NODE_AUTH_TOKEN` as environment variable name for the `NPM_TOKEN` secret

### DIFF
--- a/.changeset/brave-buckets-double.md
+++ b/.changeset/brave-buckets-double.md
@@ -1,0 +1,7 @@
+---
+"@changesets/action": major
+---
+
+use `NODE_AUTH_TOKEN` as the environment variable name for the `NPM_TOKEN` secret
+
+This matches the official GitHub `setup-node` action (documentation)[https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry].

--- a/.changeset/light-yaks-search.md
+++ b/.changeset/light-yaks-search.md
@@ -1,0 +1,7 @@
+---
+"@changesets/action": patch
+---
+
+write environment variable references to files instead of the values
+
+Within the `.npmrc` and `.netrc` files, write references to `NODE_AUTH_TOKEN` and `GITHUB_TOKEN` rather than the actual values.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ jobs:
           publish: yarn release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Send a Slack notification if a publish happens
         if: steps.changesets.outputs.published == 'true'
@@ -103,23 +103,23 @@ jobs:
         run: my-slack-bot send-notification --message "A new version of ${GITHUB_REPOSITORY} was published!"
 ```
 
-By default the GitHub Action creates a `.npmrc` file with the following content:
+If you include the `registry-url` option with the (`setup-node` Github Action)[https://github.com/actions/setup-node], the action creates a `.npmrc` file (with the following content)[https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry]:
 
 ```
-//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}
+//registry.npmjs.org/:_authToken=NODE_AUTH_TOKEN
 ```
 
-However, if a `.npmrc` file is found, the GitHub Action does not recreate the file. This is useful if you need to configure the `.npmrc` file on your own.
+If a `.npmrc` file is found, the GitHub Action does not recreate the file. This is useful if you need to configure the `.npmrc` file on your own.
 For example, you can add a step before running the Changesets GitHub Action:
 
 ```yml
 - name: Creating .npmrc
   run: |
     cat << EOF > "$HOME/.npmrc"
-      //registry.npmjs.org/:_authToken=$NPM_TOKEN
+      //registry.npmjs.org/:_authToken=\$NODE_AUTH_TOKEN
     EOF
   env:
-    NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 ```
 
 #### Custom Publishing

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,14 +73,14 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
           );
           fs.appendFileSync(
             userNpmrcPath,
-            `\n//registry.npmjs.org/:_authToken=\$\{NPM_TOKEN\}\n`
+            `\n//registry.npmjs.org/:_authToken=\$\{NODE_AUTH_TOKEN\}\n`
           );
         }
       } else {
         console.log("No user .npmrc file found, creating one");
         fs.writeFileSync(
           userNpmrcPath,
-          `//registry.npmjs.org/:_authToken=\$\{NPM_TOKEN\}\n`
+          `//registry.npmjs.org/:_authToken=\$\{NODE_AUTH_TOKEN\}\n`
         );
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
   console.log("setting GitHub credentials");
   await fs.writeFile(
     `${process.env.HOME}/.netrc`,
-    `machine github.com\nlogin github-actions[bot]\npassword ${githubToken}`
+    `machine github.com\nlogin github-actions[bot]\npassword \$GITHUB_TOKEN`
   );
 
   let { changesets } = await readChangesetState();
@@ -73,14 +73,14 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
           );
           fs.appendFileSync(
             userNpmrcPath,
-            `\n//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}\n`
+            `\n//registry.npmjs.org/:_authToken=\$\{NPM_TOKEN\}\n`
           );
         }
       } else {
         console.log("No user .npmrc file found, creating one");
         fs.writeFileSync(
           userNpmrcPath,
-          `//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}\n`
+          `//registry.npmjs.org/:_authToken=\$\{NPM_TOKEN\}\n`
         );
       }
 


### PR DESCRIPTION
depends on #267 which was extracted from this PR

context: https://github.com/changesets/action/issues/262#issuecomment-1443370427

in a follow-up PR, one could envision a `persist`: `false` option that removes these files if the action actually created them so as to perform "clean up" similar to the `persist-credentials`: `false` option for [`actions/checkout`](https://github.com/actions/checkout#checkout-v3)