### PR TITLE
add permissions to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      packages: write
+      pull-requests: write
+      issues: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -75,6 +81,12 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      packages: write
+      pull-requests: write
+      issues: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -140,6 +152,12 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      packages: write
+      pull-requests: write
+      issues: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -184,6 +202,12 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      packages: write
+      pull-requests: write
+      issues: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3


### PR DESCRIPTION
in newly created repos, GitHub Actions now defaults to giving only **read** permission on the repository, and extra permissions must be explicitly specified in the workflow file

this led to a situation where GitHub Actions can publish to npm but couldn’t publish the tag to github

this pr adds the config with the permissions required

- fixes #179
- based on #197

related #199