### PR TITLE
Support for multiple commands in version script

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -278,8 +278,11 @@ export async function runVersion({
   let versionsByDirectory = await getVersionsByDirectory(cwd);
 
   if (script) {
-    let [versionCommand, ...versionArgs] = script.split(/\s+/);
-    await exec(versionCommand, versionArgs, { cwd });
+    const scriptLines = script.split(/\r?\n/);
+    for (cosnt line of scriptLines) {
+      let [versionCommand, ...versionArgs] = line.split(/\s+/);
+      await exec(versionCommand, versionArgs, { cwd });
+    }
   } else {
     let changesetsCliPkgJson = requireChangesetsCliPkgJson(cwd);
     let cmd = semver.lt(changesetsCliPkgJson.version, "2.0.0")


### PR DESCRIPTION
I'll update docs and add some more error handling if you are open to accept this PR in general.

The use case for this is to run `pnpm install` after `changeset version`