### PR TITLE
fix: use throttling-wired octokit everywhere

### DIFF
--- a/.changeset/new-worms-knock.md
+++ b/.changeset/new-worms-knock.md
@@ -2,4 +2,4 @@
 "@changesets/action": patch
 ---
 
-use throttling plugin for all octokit instances
+Wire up [`@octokit/plugin-throttling`](https://github.com/octokit/plugin-throttling.js) with all GitHub Octokit instances

--- a/.changeset/new-worms-knock.md
+++ b/.changeset/new-worms-knock.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": patch
+---
+
+use throttling plugin for all octokit instances

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -1,5 +1,6 @@
 import fixturez from "fixturez";
 import * as github from "@actions/github";
+import * as githubUtils from "@actions/github/lib/utils";
 import fs from "fs-extra";
 import path from "path";
 import writeChangeset from "@changesets/write";
@@ -15,7 +16,19 @@ jest.mock("@actions/github", () => ({
     ref: "refs/heads/some-branch",
     sha: "xeac7",
   },
-  getOctokit: jest.fn(),
+}));
+jest.mock("@actions/github/lib/utils", () => ({
+    GitHub: {
+        plugin: () => {
+            // function necessary to be used as constructor
+            return function() {
+                return {
+                    rest: mockedGithubMethods,
+                }
+            }
+        },
+    },
+    getOctokitOptions: jest.fn(),
 }));
 jest.mock("./gitUtils");
 
@@ -30,9 +43,6 @@ let mockedGithubMethods = {
     createRelease: jest.fn(),
   },
 };
-(github.getOctokit as any).mockImplementation(() => ({
-  rest: mockedGithubMethods,
-}));
 
 let f = fixturez(__dirname);
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -61,7 +61,7 @@ const setupOctokit = (githubToken) => {
 };
 
 const createRelease = async (
-  octokit: ReturnType<typeof github.getOctokit>,
+  octokit: ReturnType<typeof GitHub>,
   { pkg, tagName }: { pkg: Package; tagName: string }
 ) => {
   try {

--- a/src/run.ts
+++ b/src/run.ts
@@ -26,6 +26,40 @@ import type {} from "@octokit/plugin-throttling/dist-types/types.d";
 // To avoid that, we ensure to cap the message to 60k chars.
 const MAX_CHARACTERS_PER_MESSAGE = 60000;
 
+const setupOctokit = (githubToken) => {
+  return new (GitHub.plugin(throttling))(
+    getOctokitOptions(githubToken, {
+      throttle: {
+        onRateLimit: (retryAfter, options: any, octokit, retryCount) => {
+          core.warning(
+            `Request quota exhausted for request ${options.method} ${options.url}`
+          );
+
+          if (retryCount <= 2) {
+            core.info(`Retrying after ${retryAfter} seconds!`);
+            return true;
+          }
+        },
+        onSecondaryRateLimit: (
+          retryAfter,
+          options: any,
+          octokit,
+          retryCount
+        ) => {
+          core.warning(
+            `SecondaryRateLimit detected for request ${options.method} ${options.url}`
+          );
+
+          if (retryCount <= 2) {
+            core.info(`Retrying after ${retryAfter} seconds!`);
+            return true;
+          }
+        },
+      },
+    })
+  );
+};
+
 const createRelease = async (
   octokit: ReturnType<typeof github.getOctokit>,
   { pkg, tagName }: { pkg: Package; tagName: string }
@@ -83,37 +117,7 @@ export async function runPublish({
   createGithubReleases,
   cwd = process.cwd(),
 }: PublishOptions): Promise<PublishResult> {
-  const octokit = new (GitHub.plugin(throttling))(
-    getOctokitOptions(githubToken, {
-      throttle: {
-        onRateLimit: (retryAfter, options: any, octokit, retryCount) => {
-          core.warning(
-            `Request quota exhausted for request ${options.method} ${options.url}`
-          );
-
-          if (retryCount <= 2) {
-            core.info(`Retrying after ${retryAfter} seconds!`);
-            return true;
-          }
-        },
-        onSecondaryRateLimit: (
-          retryAfter,
-          options: any,
-          octokit,
-          retryCount
-        ) => {
-          core.warning(
-            `SecondaryRateLimit detected for request ${options.method} ${options.url}`
-          );
-
-          if (retryCount <= 2) {
-            core.info(`Retrying after ${retryAfter} seconds!`);
-            return true;
-          }
-        },
-      },
-    })
-  );
+  const octokit = setupOctokit(githubToken);
 
   let [publishCommand, ...publishArgs] = script.split(/\s+/);
 
@@ -302,10 +306,12 @@ export async function runVersion({
   hasPublishScript = false,
   prBodyMaxCharacters = MAX_CHARACTERS_PER_MESSAGE,
 }: VersionOptions): Promise<RunVersionResult> {
+  const octokit = setupOctokit(githubToken);
+
   let repo = `${github.context.repo.owner}/${github.context.repo.repo}`;
   let branch = github.context.ref.replace("refs/heads/", "");
   let versionBranch = `changeset-release/${branch}`;
-  let octokit = github.getOctokit(githubToken);
+
   let { preState } = await readChangesetState(cwd);
 
   await gitUtils.switchToMaybeExistingBranch(versionBranch);


### PR DESCRIPTION
Related to #192.

This adds the throttling plugin to other usages of octokit that were overlooked the first time around.

cc: @Andarist 