### PR TITLE
feat: only create the .netrc file if it doesn't already exist.

### DIFF
--- a/.changeset/two-lizards-hope.md
+++ b/.changeset/two-lizards-hope.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": minor
+---
+
+Feature: only create the .netrc file if it doesn't already exist.

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,11 +27,17 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
     await gitUtils.setupUser();
   }
 
-  core.info("setting GitHub credentials");
-  await fs.writeFile(
-    `${process.env.HOME}/.netrc`,
-    `machine github.com\nlogin github-actions[bot]\npassword ${githubToken}`
-  );
+  let netrcFilepath = `${process.env.HOME}/.netrc`;
+
+  if (!fs.existsSync(netrcFilepath)) {
+    core.info("setting GitHub credentials");
+    await fs.writeFile(
+      netrcFilepath,
+      `machine github.com\nlogin github-actions[bot]\npassword ${githubToken}`
+    );
+  } else {
+    core.info("GitHub credentials file exists, skipping.Wrap t")
+  }
 
   let { changesets } = await readChangesetState();
 


### PR DESCRIPTION
This allows custom user configuration to be used by the action without having to explicitly configure the action to support this.