### PR TITLE
Allow actions to specify target registry domain to publish

### DIFF
--- a/.changeset/few-games-impress.md
+++ b/.changeset/few-games-impress.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": minor
+---
+
+allow custom registry

--- a/README.md
+++ b/README.md
@@ -122,6 +122,21 @@ For example, you can add a step before running the Changesets GitHub Action:
     NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 ```
 
+If you want to publish package to other registry than NPM, you can do that by providing custom registry domain. GitHub Actions will create a `.npmrc` accordingly to specified registry.
+For example, you can specify changeset to publish a package to GitHub Pcakages
+
+```yml
+- name: Create Release Pull Request or Publish to GitHub Packages
+  id: changesets
+  uses: changesets/action@v1
+  with:
+    publish: yarn release
+    registry: npm.pkg.github.com
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+```
+
 #### Custom Publishing
 
 If you want to hook into when publishing should occur but have your own publishing functionality you can utilize the `hasChangesets` output.

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: "A boolean value to indicate whether to create Github releases after `publish` or not"
     required: false
     default: true
+  registry:
+    description: "Specify the registry to publish to. Default to `registry.npmjs.org`"
+    required: false
+    default: "registry.npmjs.org"
 outputs:
   published:
     description: A boolean value to indicate whether a publishing is happened or not

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,32 +55,40 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
         "No changesets found, attempting to publish any unpublished packages to npm"
       );
 
+      let registry = core.getInput("registry");
       let userNpmrcPath = `${process.env.HOME}/.npmrc`;
+
+      core.info(`Publishing will be targeted to the registry: ${registry}`);
+
       if (fs.existsSync(userNpmrcPath)) {
         core.info("Found existing user .npmrc file");
         const userNpmrcContent = await fs.readFile(userNpmrcPath, "utf8");
         const authLine = userNpmrcContent.split("\n").find((line) => {
-          // check based on https://github.com/npm/cli/blob/8f8f71e4dd5ee66b3b17888faad5a7bf6c657eed/test/lib/adduser.js#L103-L105
-          return /^\s*\/\/registry\.npmjs\.org\/:[_-]authToken=/i.test(line);
+          // create regex from string, allowing to adapt with any custom registry
+          const registryRegex = new RegExp(
+            `^\\s*//${registry}/:[_-]authToken=`,
+            "i"
+          );
+          return registryRegex.test(line);
         });
         if (authLine) {
           core.info(
-            "Found existing auth token for the npm registry in the user .npmrc file"
+            "Found existing auth token for the registry in the user .npmrc file"
           );
         } else {
           core.info(
-            "Didn't find existing auth token for the npm registry in the user .npmrc file, creating one"
+            "Didn't find existing auth token for the registry in the user .npmrc file, creating one"
           );
           fs.appendFileSync(
             userNpmrcPath,
-            `\n//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}\n`
+            `\n//${registry}/:_authToken=${process.env.NPM_TOKEN}\n`
           );
         }
       } else {
         core.info("No user .npmrc file found, creating one");
         fs.writeFileSync(
           userNpmrcPath,
-          `//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}\n`
+          `//${registry}/:_authToken=${process.env.NPM_TOKEN}\n`
         );
       }
 


### PR DESCRIPTION
At the moment GitHub Actions will create `.npmrc` that only point to default's NPM registry (which is `registry.npmjs.org`). This actions option will allow user to change registry domain that script will create, and configure.