### PR TITLE
fix: :bug: Fix tags not triggering github create event

### DIFF
--- a/.changeset/many-gifts-sort.md
+++ b/.changeset/many-gifts-sort.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": patch
+---
+
+Fix tags not triggering github create event

--- a/src/gitUtils.ts
+++ b/src/gitUtils.ts
@@ -29,8 +29,17 @@ export const push = async (
   );
 };
 
+/**
+ * Push new tags 1 by 1 to avoid github create event limits
+ */
 export const pushTags = async () => {
-  await exec("git", ["push", "origin", "--tags"]);
+  const tagsOutput = await getExecOutput("git tag --contains HEAD");
+  const tagsArray = tagsOutput.stdout.split("\n").filter(Boolean);
+  await Promise.all(
+    tagsArray.map(async (tag) => {
+      await getExecOutput(`git push origin ${tag}`);
+    })
+  );
 };
 
 export const switchToMaybeExistingBranch = async (branch: string) => {


### PR DESCRIPTION
We've been loving changesets!

However, I think I finally tracked down an issue we were having.
Our monorepo has a cloudbuild trigger listening to tags, but github doesn't create a `Create` event [when more than 3 tags are created at once](https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#create)... which is unfortunate when we have changes in 5 of our apps... 

I did a local test to confirm that as long as tags are pushed one at a time, they all trigger github events. 

Let me know if anything should be adjusted or if I didn't account for something!