### PR TITLE
Mention required tags for option `createGithubReleases`

### DIFF
--- a/.changeset/fifty-swans-perform.md
+++ b/.changeset/fifty-swans-perform.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": patch
+---
+
+Mention required tags for option `createGithubReleases`

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This action for [Changesets](https://github.com/atlassian/changesets) creates a 
 - commit - The commit message to use. Default to `Version Packages`
 - title - The pull request title. Default to `Version Packages`
 - setupGitUser - Sets up the git user for commits as `"github-actions[bot]"`. Default to `true`
-- createGithubReleases - A boolean value to indicate whether to create Github releases after `publish` or not. Default to `true`
+- createGithubReleases - A boolean value to indicate whether to create Github releases after `publish` or not. Default to `true` (Make sure the required tags are created, i.e. by running `changeset tag` in your `publish` script)
 - cwd - Changes node's `process.cwd()` if the project is not located on the root. Default to `process.cwd()`
 
 ### Outputs


### PR DESCRIPTION
Relates #260 
It is necessary, that the tags are created, in order for the script to create the github releases. This kinda makes sense if you think about it. The problem is that this does not seem to be included into the readme at this point, and there is no warning (or even a fail) in the cli that this would be required.

First things first, let's inform the users in the readme