### PR TITLE
Allow a custom command to run before commit

### DIFF
--- a/.changeset/blue-fans-speak.md
+++ b/.changeset/blue-fans-speak.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": minor
+---
+
+Add a `beforeCommit` input to allow users to run a custom command before version changes are committed

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This action for [Changesets](https://github.com/atlassian/changesets) creates a 
 
 - publish - The command to use to build and publish packages
 - version - The command to update version, edit CHANGELOG, read and delete changesets. Default to `changeset version` if not provided
+- beforeCommit - Optional command to run before commit.
 - commit - The commit message to use. Default to `Version Packages`
 - title - The pull request title. Default to `Version Packages`
 - setupGitUser - Sets up the git user for commits as `"github-actions[bot]"`. Default to `true`

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
   cwd:
     description: Sets the cwd for the node process. Default to `process.cwd()`
     required: false
+  beforeCommit:
+    description: Optional command to run before commit
+    required: false
   commit:
     description: |
       The commit message. Default to `Version Packages`

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,6 +105,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
     case hasChangesets:
       const { pullRequestNumber } = await runVersion({
         script: getOptionalInput("version"),
+        beforeCommit: getOptionalInput("beforeCommit"),
         githubToken,
         prTitle: getOptionalInput("title"),
         commitMessage: getOptionalInput("commit"),

--- a/src/run.ts
+++ b/src/run.ts
@@ -293,6 +293,7 @@ export async function getVersionPrBody({
 
 type VersionOptions = {
   script?: string;
+  beforeCommit?: string;
   githubToken: string;
   cwd?: string;
   prTitle?: string;
@@ -307,6 +308,7 @@ type RunVersionResult = {
 
 export async function runVersion({
   script,
+  beforeCommit,
   githubToken,
   cwd = process.cwd(),
   prTitle = "Version Packages",
@@ -363,6 +365,11 @@ export async function runVersion({
   );
 
   const finalPrTitle = `${prTitle}${!!preState ? ` (${preState.tag})` : ""}`;
+
+  if (beforeCommit) {
+    let [commitCommand, ...commitArgs] = beforeCommit.split(/\s+/);
+    await exec(commitCommand, commitArgs, { cwd });
+  }
 
   // project with `commit: true` setting could have already committed files
   if (!(await gitUtils.checkIfClean())) {


### PR DESCRIPTION
This PR adds a `beforeCommit` input to allow users to run a custom command before version changes are committed and pushed to the release PR. This can be useful:

- to run additional commands after a version bump
- as an escape hatch to commit the files with different tools like https://github.com/int128/ghcp or the GitHub API (to have signed commits without the need of a bot or app).