### PR TITLE
chore: bump nodejs from 16 to 20

### DIFF
--- a/.changeset/kind-sheep-grab.md
+++ b/.changeset/kind-sheep-grab.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": patch
+---
+
+Bump the used node.js from 16 to 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
 
-      - name: Use Node.js 16
+      - name: Use Node.js 20
         uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - name: Install Dependencies
         run: yarn --frozen-lockfile

--- a/.github/workflows/version-or-publish.yml
+++ b/.github/workflows/version-or-publish.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
 
-      - name: Use Node.js 16
+      - name: Use Node.js 20
         uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - name: Install Dependencies
         run: yarn --frozen-lockfile

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
-      - name: Setup Node.js 16
+      - name: Setup Node.js 20
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
 
       - name: Install Dependencies
         run: yarn
@@ -79,10 +79,10 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
-      - name: Setup Node.js 16.x
+      - name: Setup Node.js 20.x
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - name: Install Dependencies
         run: yarn
@@ -144,10 +144,10 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
-      - name: Setup Node.js 16.x
+      - name: Setup Node.js 20.x
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - name: Install Dependencies
         run: yarn
@@ -188,10 +188,10 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
-      - name: Setup Node.js 16.x
+      - name: Setup Node.js 20.x
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - name: Install Dependencies
         run: yarn

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: Changesets
 description: A GitHub action to automate releases with Changesets
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"
 inputs:
   publish:

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@babel/preset-typescript": "^7.13.0",
     "@types/fs-extra": "^8.0.0",
     "@types/jest": "^29.5.1",
-    "@types/node": "^12.7.1",
+    "@types/node": "^20.11.17",
     "@types/semver": "^7.5.0",
     "babel-jest": "^29.5.0",
     "husky": "^3.0.3",
@@ -31,7 +31,7 @@
     "release": "node ./scripts/release.js"
   },
   "engines": {
-    "node": ">= 16"
+    "node": ">= 20"
   },
   "dependencies": {
     "@actions/core": "^1.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1733,6 +1733,13 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
   integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
 
+"@types/node@^20.11.17":
+  version "20.11.17"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.17.tgz#cdd642d0e62ef3a861f88ddbc2b61e32578a9292"
+  integrity sha512-QmgQZGWu1Yw9TDyAP9ZzpFJKynYNeOvwMJmaxABfieQoVoiVOS6MN1WSpqpRcbeA5+RW82kraAVxCCJg+780Qw==
+  dependencies:
+    undici-types "~5.26.4"
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
@@ -4847,6 +4854,11 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 unherit@^1.0.4:
   version "1.1.3"


### PR DESCRIPTION
Hi. Node.js 16 actions are deprecated now.
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/