### PR TITLE
Feat/private registry

### DIFF
--- a/.changeset/nice-tips-heal.md
+++ b/.changeset/nice-tips-heal.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": minor
+---
+
+enable support for other private registry

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,8 +60,10 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
         core.info("Found existing user .npmrc file");
         const userNpmrcContent = await fs.readFile(userNpmrcPath, "utf8");
         const authLine = userNpmrcContent.split("\n").find((line) => {
-          // check based on https://github.com/npm/cli/blob/8f8f71e4dd5ee66b3b17888faad5a7bf6c657eed/test/lib/adduser.js#L103-L105
-          return /^\s*\/\/registry\.npmjs\.org\/:[_-]authToken=/i.test(line);
+          // npm registry format: https://github.com/npm/cli/blob/8f8f71e4dd5ee66b3b17888faad5a7bf6c657eed/test/lib/adduser.js#L103-L105
+          // github registry format: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry#authenticating-with-a-personal-access-token
+          // also allow support for custom domain format, eg: //code.org.com/packages/npm/:_authToken=
+          return /:[_-]authToken=/i.test(line);
         });
         if (authLine) {
           core.info(


### PR DESCRIPTION
I've encounter problem when using changesets/action when I'm using the private registry that is not npm.

Upon looking into it the problem seems to coming from the bellow line where it only check for npm registry name.
```
const authLine = userNpmrcContent.split("\n").find((line) => {
  // check based on https://github.com/npm/cli/blob/8f8f71e4dd5ee66b3b17888faad5a7bf6c657eed/test/lib/adduser.js#L103-L105
  return /^\s*\/\/registry\.npmjs\.org\/:[_-]authToken=/i.test(line);
});
```

However, beside npm registry, we also have github registry and custom domain gitlab registry.
```
// npm
//registry.npmjs.org/:_authToken

// github
//npm.pkg.github.com/:_authToken=TOKEN

// custom domain gitlab registry
//code.org.com/packages/npm/:_authToken=
```

Hence I'm making the change here to address for this problem.
Thank you the team for your work on maintaining this tool!