### PR TITLE
Add customize PR branch name 

### DIFF
--- a/.changeset/good-mice-brake.md
+++ b/.changeset/good-mice-brake.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": patch
+---
+
+Allow customize branch name

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,9 @@ inputs:
     description: "A boolean value to indicate whether to create Github releases after `publish` or not"
     required: false
     default: true
+  branchName:
+    description: Sets the branch name for the pull request. Default to `changeset-release/{{$github.ref_name}}`
+    required: false
   branch:
     description: Sets the branch in which the action will run. Default to `github.ref_name` if not provided
     required: false

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,6 +110,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
         commitMessage: getOptionalInput("commit"),
         hasPublishScript,
         branch: getOptionalInput("branch"),
+        branchName: getOptionalInput("branchName"),
       });
 
       core.setOutput("pullRequestNumber", String(pullRequestNumber));

--- a/src/run.ts
+++ b/src/run.ts
@@ -18,9 +18,7 @@ import readChangesetState from "./readChangesetState";
 import resolveFrom from "resolve-from";
 import { throttling } from "@octokit/plugin-throttling";
 
-// GitHub Issues/PRs messages have a max size limit on th
-
-
+// GitHub Issues/PRs messages have a max size limit on the
 // message body payload.
 // `body is too long (maximum is 65536 characters)`.
 // To avoid that, we ensure to cap the message to 60k chars.

--- a/src/run.ts
+++ b/src/run.ts
@@ -18,7 +18,9 @@ import readChangesetState from "./readChangesetState";
 import resolveFrom from "resolve-from";
 import { throttling } from "@octokit/plugin-throttling";
 
-// GitHub Issues/PRs messages have a max size limit on the
+// GitHub Issues/PRs messages have a max size limit on th
+
+
 // message body payload.
 // `body is too long (maximum is 65536 characters)`.
 // To avoid that, we ensure to cap the message to 60k chars.
@@ -300,6 +302,7 @@ type VersionOptions = {
   hasPublishScript?: boolean;
   prBodyMaxCharacters?: number;
   branch?: string;
+  branchName?: string;
 };
 
 type RunVersionResult = {
@@ -315,12 +318,13 @@ export async function runVersion({
   hasPublishScript = false,
   prBodyMaxCharacters = MAX_CHARACTERS_PER_MESSAGE,
   branch,
+  branchName
 }: VersionOptions): Promise<RunVersionResult> {
   const octokit = setupOctokit(githubToken);
 
   let repo = `${github.context.repo.owner}/${github.context.repo.repo}`;
   branch = branch ?? github.context.ref.replace("refs/heads/", "");
-  let versionBranch = `changeset-release/${branch}`;
+  let versionBranch = branchName ?? `changeset-release/${branch}`;
 
   let { preState } = await readChangesetState(cwd);
 


### PR DESCRIPTION
As of previous PR #255, it's possible to trigger the Changeset Pull Request process from a branch other than `baseBranch`. Thanks for this, it's really useful  🙏

If two branches want to merge into `baseBranch`, the PR branch name will always be `changeset-release/{{baseBranch}}`. In this case, the latest commit will override the branch. 

But sometimes we just want two different branches. For example, in a Git workflow where the release can come from the `develop` branch or the `hotfixes` branch.

It should be possible to do this workflow with this PR

![schema](https://github.com/changesets/action/assets/7901622/6041b630-be84-4d95-93af-a247810edbfc)

