### PR TITLE
feat: add baseBranch option

### DIFF
--- a/.changeset/unlucky-lies-brush.md
+++ b/.changeset/unlucky-lies-brush.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": minor
+---
+
+add option 'baseBranch'

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This action for [Changesets](https://github.com/atlassian/changesets) creates a 
 - setupGitUser - Sets up the git user for commits as `"github-actions[bot]"`. Default to `true`
 - createGithubReleases - A boolean value to indicate whether to create Github releases after `publish` or not. Default to `true`
 - cwd - Changes node's `process.cwd()` if the project is not located on the root. Default to `process.cwd()`
+- baseBranch - The branch to create the pull request against. Default to the branch the action is running on.
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,9 @@ inputs:
   branch:
     description: Sets the branch in which the action will run. Default to `github.ref_name` if not provided
     required: false
+  baseBranch:
+    description: Sets the base branch for the pull request. Default to the branch the action runs on if not provided
+    required: false
 outputs:
   published:
     description: A boolean value to indicate whether a publishing is happened or not

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,6 +110,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
         commitMessage: getOptionalInput("commit"),
         hasPublishScript,
         branch: getOptionalInput("branch"),
+        baseBranch: getOptionalInput("baseBranch"),
       });
 
       core.setOutput("pullRequestNumber", String(pullRequestNumber));

--- a/src/run.ts
+++ b/src/run.ts
@@ -300,6 +300,7 @@ type VersionOptions = {
   hasPublishScript?: boolean;
   prBodyMaxCharacters?: number;
   branch?: string;
+  baseBranch?: string;
 };
 
 type RunVersionResult = {
@@ -315,11 +316,13 @@ export async function runVersion({
   hasPublishScript = false,
   prBodyMaxCharacters = MAX_CHARACTERS_PER_MESSAGE,
   branch,
+  baseBranch,
 }: VersionOptions): Promise<RunVersionResult> {
   const octokit = setupOctokit(githubToken);
 
   let repo = `${github.context.repo.owner}/${github.context.repo.repo}`;
   branch = branch ?? github.context.ref.replace("refs/heads/", "");
+  baseBranch ??= branch;
   let versionBranch = `changeset-release/${branch}`;
 
   let { preState } = await readChangesetState(cwd);
@@ -396,7 +399,7 @@ export async function runVersion({
   if (existingPullRequests.data.length === 0) {
     core.info("creating pull request");
     const { data: newPullRequest } = await octokit.rest.pulls.create({
-      base: branch,
+      base: baseBranch,
       head: versionBranch,
       title: finalPrTitle,
       body: prBody,


### PR DESCRIPTION
Closes https://github.com/changesets/action/issues/368

## Change summary

This change adds a new action input `baseBranch`, which allows specifying the branch on which the PR will be opened on. This is useful for hotfixes. In my case, I trigger a release on merging to main, and this change would allow me to open a PR straight to main with the cherry-picked changes.

## Specifications

A new input, `baseBranch`, can be specified to open the PR onto that branch. If not specified, the behavior will be as before, the PR would be opened on the branch the action runs on.

## Example

Here's how running a hotfix workflow would look like:

![hotfix_action](https://github.com/changesets/action/assets/95138356/c019d453-333c-4c41-b0f3-ddc373b2eb60)

The full workflow can be seen here https://github.com/prenaissance/changesets-test/blob/master/.github/workflows/changesets.yml