### PR TITLE
Added makeGitHubReleasesLatest input

### DIFF
--- a/.changeset/tiny-boxes-visit.md
+++ b/.changeset/tiny-boxes-visit.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": minor
+---
+
+Added `makeGitHubReleasesLatest` input which controls whether created GitHub releases are marked as latest or not

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This action for [Changesets](https://github.com/atlassian/changesets) creates a 
 - title - The pull request title. Default to `Version Packages`
 - setupGitUser - Sets up the git user for commits as `"github-actions[bot]"`. Default to `true`
 - createGithubReleases - A boolean value to indicate whether to create Github releases after `publish` or not. Default to `true`
+- makeGitHubReleasesLatest - A boolean value to indicate whether to make the created GitHub releases latest or not. Default to `true`
 - cwd - Changes node's `process.cwd()` if the project is not located on the root. Default to `process.cwd()`
 
 ### Outputs

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: "A boolean value to indicate whether to create Github releases after `publish` or not"
     required: false
     default: true
+  makeGitHubReleasesLatest:
+    description: "A boolean value to indicate whether to make the created GitHub releases latest or not"
+    required: false
+    default: true
   branch:
     description: Sets the branch in which the action will run. Default to `github.ref_name` if not provided
     required: false

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
         script: publishScript,
         githubToken,
         createGithubReleases: core.getBooleanInput("createGithubReleases"),
+        makeGitHubReleasesLatest: core.getBooleanInput("makeGitHubReleasesLatest"),
       });
 
       if (result.published) {

--- a/src/run.ts
+++ b/src/run.ts
@@ -60,7 +60,7 @@ const setupOctokit = (githubToken: string) => {
 
 const createRelease = async (
   octokit: ReturnType<typeof setupOctokit>,
-  { pkg, tagName }: { pkg: Package; tagName: string }
+  { pkg, tagName, makeLatest }: { pkg: Package; tagName: string; makeLatest: boolean }
 ) => {
   try {
     let changelogFileName = path.join(pkg.dir, "CHANGELOG.md");
@@ -81,6 +81,7 @@ const createRelease = async (
       tag_name: tagName,
       body: changelogEntry.content,
       prerelease: pkg.packageJson.version.includes("-"),
+      make_latest: makeLatest,
       ...github.context.repo,
     });
   } catch (err) {
@@ -100,6 +101,7 @@ type PublishOptions = {
   script: string;
   githubToken: string;
   createGithubReleases: boolean;
+  makeGitHubReleasesLatest: boolean;
   cwd?: string;
 };
 
@@ -118,6 +120,7 @@ export async function runPublish({
   script,
   githubToken,
   createGithubReleases,
+  makeGitHubReleasesLatest,
   cwd = process.cwd(),
 }: PublishOptions): Promise<PublishResult> {
   const octokit = setupOctokit(githubToken);
@@ -161,6 +164,7 @@ export async function runPublish({
           createRelease(octokit, {
             pkg,
             tagName: `${pkg.packageJson.name}@${pkg.packageJson.version}`,
+            makeLatest: makeGitHubReleasesLatest,
           })
         )
       );
@@ -184,6 +188,7 @@ export async function runPublish({
           await createRelease(octokit, {
             pkg,
             tagName: `v${pkg.packageJson.version}`,
+            makeLatest: makeGitHubReleasesLatest,
           });
         }
         break;


### PR DESCRIPTION
Resolves #340 

This PR adds a `makeGitHubReleasesLatest` input which controls whether the created GitHub releases are marked as latest or not. It defaults to `true` which is the same as the GitHub API's default value. This makes this change backwards compatible.

This addition will be useful since, especially in a monorepo setup, marking the releases of subpackges as latest is not desirable.

Please let me know if you wanted me to introduce any modifications to the approach. 