### PR TITLE
Switch to pull request list API instead of search

### DIFF
--- a/.changeset/clean-bees-count.md
+++ b/.changeset/clean-bees-count.md
@@ -2,4 +2,4 @@
 "@changesets/action": patch
 ---
 
-Ensure the PR remains opwn when updated
+Ensure the PR remains open when updated

--- a/.changeset/clean-bees-count.md
+++ b/.changeset/clean-bees-count.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": patch
+---
+
+Ensure the PR remains opwn when updated

--- a/.changeset/green-eels-appear.md
+++ b/.changeset/green-eels-appear.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": patch
+---
+
+Switch to cheaper API for querying existing PRs

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -33,11 +33,9 @@ jest.mock("@actions/github/lib/utils", () => ({
 jest.mock("./gitUtils");
 
 let mockedGithubMethods = {
-  search: {
-    issuesAndPullRequests: jest.fn(),
-  },
   pulls: {
     create: jest.fn(),
+    list: jest.fn(),
   },
   repos: {
     createRelease: jest.fn(),
@@ -65,9 +63,7 @@ describe("version", () => {
     let cwd = f.copy("simple-project");
     linkNodeModules(cwd);
 
-    mockedGithubMethods.search.issuesAndPullRequests.mockImplementationOnce(
-      () => ({ data: { items: [] } })
-    );
+    mockedGithubMethods.pulls.list.mockImplementationOnce(() => ({ data: [] }));
 
     mockedGithubMethods.pulls.create.mockImplementationOnce(() => ({
       data: { number: 123 },
@@ -104,9 +100,7 @@ describe("version", () => {
     let cwd = f.copy("simple-project");
     linkNodeModules(cwd);
 
-    mockedGithubMethods.search.issuesAndPullRequests.mockImplementationOnce(
-      () => ({ data: { items: [] } })
-    );
+    mockedGithubMethods.pulls.list.mockImplementationOnce(() => ({ data: [] }));
 
     mockedGithubMethods.pulls.create.mockImplementationOnce(() => ({
       data: { number: 123 },
@@ -139,9 +133,7 @@ describe("version", () => {
     let cwd = f.copy("ignored-package");
     linkNodeModules(cwd);
 
-    mockedGithubMethods.search.issuesAndPullRequests.mockImplementationOnce(
-      () => ({ data: { items: [] } })
-    );
+    mockedGithubMethods.pulls.list.mockImplementationOnce(() => ({ data: [] }));
 
     mockedGithubMethods.pulls.create.mockImplementationOnce(() => ({
       data: { number: 123 },
@@ -174,9 +166,7 @@ describe("version", () => {
     let cwd = f.copy("simple-project");
     linkNodeModules(cwd);
 
-    mockedGithubMethods.search.issuesAndPullRequests.mockImplementationOnce(
-      () => ({ data: { items: [] } })
-    );
+    mockedGithubMethods.pulls.list.mockImplementationOnce(() => ({ data: [] }));
 
     mockedGithubMethods.pulls.create.mockImplementationOnce(() => ({
       data: { number: 123 },
@@ -233,9 +223,7 @@ fluminis divesque vulnere aquis parce lapsis rabie si visa fulmineis.
     let cwd = f.copy("simple-project");
     linkNodeModules(cwd);
 
-    mockedGithubMethods.search.issuesAndPullRequests.mockImplementationOnce(
-      () => ({ data: { items: [] } })
-    );
+    mockedGithubMethods.pulls.list.mockImplementationOnce(() => ({ data: [] }));
 
     mockedGithubMethods.pulls.create.mockImplementationOnce(() => ({
       data: { number: 123 },

--- a/src/run.ts
+++ b/src/run.ts
@@ -415,6 +415,7 @@ export async function runVersion({
       title: finalPrTitle,
       body: prBody,
       ...github.context.repo,
+      state: "open",
     });
 
     return {


### PR DESCRIPTION
To reduce the amount of rate-limit that we use, switch to a cheaper API for determining whether an existing PR exists for a given branch.

This should avoid hitting the secondary rate limits as much

Context: https://github.com/changesets/action/pull/391#issuecomment-2309938444

See also #192 


Tested here:
* https://github.com/s0/changesets-action/pull/8
* workflow run (notice no rate-limit warnings): https://github.com/s0/changesets-action/actions/runs/10558945878/job/29249383365
