### PR TITLE
add alpha sort to pull request releases list

### DIFF
--- a/.changeset/brave-panthers-invent.md
+++ b/.changeset/brave-panthers-invent.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": minor
+---
+
+add alpha sort to pull request releases list

--- a/src/__snapshots__/utils.test.ts.snap
+++ b/src/__snapshots__/utils.test.ts.snap
@@ -8,6 +8,11 @@ exports[`it sorts the things right 1`] = `
     "private": false,
   },
   {
+    "highestLevel": 3,
+    "name": "d",
+    "private": false,
+  },
+  {
     "highestLevel": 1,
     "name": "b",
     "private": false,

--- a/src/run.ts
+++ b/src/run.ts
@@ -362,6 +362,7 @@ export async function runVersion({
         private: !!pkg.packageJson.private,
         content: entry.content,
         header: `## ${pkg.packageJson.name}@${pkg.packageJson.version}`,
+        name: pkg.packageJson.name,
       };
     })
   );

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -92,6 +92,11 @@ test("it sorts the things right", () => {
       private: false,
     },
     {
+      name: "d",
+      highestLevel: BumpLevels.major,
+      private: false,
+    },
+    {
       name: "c",
       highestLevel: BumpLevels.major,
       private: false,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -87,10 +87,18 @@ export function getChangelogEntry(changelog: string, version: string) {
 }
 
 export function sortTheThings(
-  a: { private: boolean; highestLevel: number },
-  b: { private: boolean; highestLevel: number }
+  a: { private: boolean; highestLevel: number; name: string },
+  b: { private: boolean; highestLevel: number; name: string }
 ) {
   if (a.private === b.private) {
+    if (a.highestLevel === b.highestLevel) {
+      if (a.name > b.name) {
+        return 1;
+      }
+      if (a.name < b.name) {
+        return -1;
+      }
+    }
     return b.highestLevel - a.highestLevel;
   }
   if (a.private) {


### PR DESCRIPTION
This preserves the current sorting logic for public vs private and keeping major above minor above patches. Currently, within a given grouping (i.e. private packages with minor version bumps), the sorting is arbitrary. This ensures that the pull request body will list package names in alpha order.