### PR TITLE
Improve error message when attempting to publish without publish script defined

### DIFF
--- a/.changeset/breezy-garlics-bathe.md
+++ b/.changeset/breezy-garlics-bathe.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": patch
+---
+
+Improve error message when attempting to publish without publish script defined

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
       return;
     case !hasChangesets && hasPublishScript: {
       core.info(
-        "Attempting to publish any unpublished packages to npm"
+        "No changesets found. Attempting to publish any unpublished packages to npm"
       );
 
       let userNpmrcPath = `${process.env.HOME}/.npmrc`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
 
   switch (true) {
     case !hasChangesets && !hasPublishScript:
-      core.info("No publish script found");
+      core.info("No changesets present or were removed by merging release PR. Not publishing because no publish script found.");
       return;
     case !hasChangesets && hasPublishScript: {
       core.info(

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,11 +48,11 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
 
   switch (true) {
     case !hasChangesets && !hasPublishScript:
-      core.info("No changesets found");
+      core.info("No publish script found");
       return;
     case !hasChangesets && hasPublishScript: {
       core.info(
-        "No changesets found, attempting to publish any unpublished packages to npm"
+        "Attempting to publish any unpublished packages to npm"
       );
 
       let userNpmrcPath = `${process.env.HOME}/.npmrc`;


### PR DESCRIPTION
Prior to this PR it would tell you `No changesets found` if you omitted the `publish` script, and it was very hard to figure out what to do. It was also misleading as the only reason there were no changesets present is because they were deleted earlier in the release process