### PR TITLE
docs: Update documentation to reflect changesets publish expected environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,15 @@ jobs:
           publish: yarn release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # Expected env variable by changeset publish
 
       - name: Send a Slack notification if a publish happens
         if: steps.changesets.outputs.published == 'true'
         # You can do something when a publish happens.
         run: my-slack-bot send-notification --message "A new version of ${GITHUB_REPOSITORY} was published!"
 ```
+
+**Note**: Consider when you are using the `changesets/action` in combination with `changeset publish`, you are required to use `NODE_AUTH_TOKEN` instead of `NPM_TOKEN` environment variable.
 
 By default the GitHub Action creates a `.npmrc` file with the following content:
 


### PR DESCRIPTION
# Changelog

- Documentation updated to assist with the usage of the action in combination with `changesets publish`

fixes https://github.com/changesets/changesets/issues/942

## Additional context

I wanted to add some background to this PR to provide better context for the reviewers to assist with the approval. The environment variable is defined by how NodeJS is set up within the GitHub Action Setup-node, which will automatically create a `.npmrc` file using this as an environment variable.

Therefore, the action expects us to use this variable over others, while if you decide to create your own `.npmrc,` we will be in control. As we can see on [here](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#publish-to-npmjs-and-gpr-with-npm). Hence the documentation updated to align with the previous steps above to align with the setup-node specifications mitigating potential issues when developer use the code given in the Readme