### PR TITLE
Use full git email for github-actions bot

### DIFF
--- a/src/gitUtils.ts
+++ b/src/gitUtils.ts
@@ -9,7 +9,7 @@ export const setupUser = async () => {
   await exec("git", [
     "config",
     "user.email",
-    `"github-actions[bot]@users.noreply.github.com"`,
+    `"41898282+github-actions[bot]@users.noreply.github.com"`,
   ]);
 };
 


### PR DESCRIPTION
The full git email for `github-actions[bot]` has the initial `41898282+` part.

Initially I thought fixing this would make GitHub no longer generate co-author descriptions by default, because the PR author and the commit author are already the same bot. [Example](https://github.com/publint/publint/commit/dedc34ece273654da647e3214dc12a26787aa99a). But after [fixing the email myself](https://github.com/publint/publint/commit/6826b0a8dd3a205657293fa62689cc69c4206405) and releasing again, the co-author is still there. [Example](https://github.com/publint/publint/commit/7fb275a41defb5e161711f6cf1f96156d2817552)

So while this doesn't quite fix anything, and I could also remove the co-author manually if I wanted, I thought it's still beneficial to update this to be consistent and maybe one day GitHub might fix this.

NOTE: The original full email can be retrieved by prepending `.patch` to the commit URLs above. [Example](https://github.com/publint/publint/commit/dedc34ece273654da647e3214dc12a26787aa99a.patch)