### PR TITLE
update: change double negative variable and remove unused variable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,8 +37,8 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
 
   let publishScript = core.getInput("publish");
   let hasChangesets = changesets.length !== 0;
-  const hasNonEmptyChangesets = changesets.some(
-    (changeset) => changeset.releases.length > 0
+  const isAllChangesetsEmpty = changesets.every(
+    (changeset) => changeset.releases.length === 0
   );
   let hasPublishScript = !!publishScript;
 
@@ -48,7 +48,9 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
 
   switch (true) {
     case !hasChangesets && !hasPublishScript:
-      core.info("No changesets present or were removed by merging release PR. Not publishing because no publish script found.");
+      core.info(
+        "No changesets present or were removed by merging release PR. Not publishing because no publish script found."
+      );
       return;
     case !hasChangesets && hasPublishScript: {
       core.info(
@@ -99,7 +101,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
       }
       return;
     }
-    case hasChangesets && !hasNonEmptyChangesets:
+    case hasChangesets && isAllChangesetsEmpty:
       core.info("All changesets are empty; not creating PR");
       return;
     case hasChangesets:

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,8 +37,8 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
 
   let publishScript = core.getInput("publish");
   let hasChangesets = changesets.length !== 0;
-  const isAllChangesetsEmpty = changesets.every(
-    (changeset) => changeset.releases.length === 0
+  const hasNonEmptyChangesets = changesets.some(
+    (changeset) => changeset.releases.length > 0
   );
   let hasPublishScript = !!publishScript;
 
@@ -48,9 +48,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
 
   switch (true) {
     case !hasChangesets && !hasPublishScript:
-      core.info(
-        "No changesets present or were removed by merging release PR. Not publishing because no publish script found."
-      );
+      core.info("No changesets present or were removed by merging release PR. Not publishing because no publish script found.");
       return;
     case !hasChangesets && hasPublishScript: {
       core.info(
@@ -101,7 +99,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
       }
       return;
     }
-    case hasChangesets && isAllChangesetsEmpty:
+    case hasChangesets && !hasNonEmptyChangesets:
       core.info("All changesets are empty; not creating PR");
       return;
     case hasChangesets:

--- a/src/run.ts
+++ b/src/run.ts
@@ -318,7 +318,6 @@ export async function runVersion({
 }: VersionOptions): Promise<RunVersionResult> {
   const octokit = setupOctokit(githubToken);
 
-  let repo = `${github.context.repo.owner}/${github.context.repo.repo}`;
   branch = branch ?? github.context.ref.replace("refs/heads/", "");
   let versionBranch = `changeset-release/${branch}`;
 


### PR DESCRIPTION
Update double negative variable for readability, and we don't use repo variable as we directly send `github.context.repo.repo` to octokit