### PR TITLE
Do not pre-start github API request

### DIFF
--- a/.changeset/quiet-jeans-poke.md
+++ b/.changeset/quiet-jeans-poke.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": patch
+---
+
+Avoid searching for an existing pull request early.

--- a/src/run.ts
+++ b/src/run.ts
@@ -300,12 +300,6 @@ export async function runVersion({
     });
   }
 
-  const existingPullRequestsPromise = octokit.rest.pulls.list({
-    ...github.context.repo,
-    state: "open",
-    head: `${github.context.repo.owner}:${versionBranch}`,
-    base: branch,
-  });
   let changedPackages = await getChangedPackages(cwd, versionsByDirectory);
   let changedPackagesInfoPromises = Promise.all(
     changedPackages.map(async (pkg) => {
@@ -331,7 +325,12 @@ export async function runVersion({
 
   await git.pushChanges({ branch: versionBranch, message: finalCommitMessage });
 
-  let existingPullRequests = await existingPullRequestsPromise;
+  let existingPullRequests = await octokit.rest.pulls.list({
+    ...github.context.repo,
+    state: "open",
+    head: `${github.context.repo.owner}:${versionBranch}`,
+    base: branch,
+  });
   core.info(JSON.stringify(existingPullRequests.data, null, 2));
 
   const changedPackagesInfo = (await changedPackagesInfoPromises)


### PR DESCRIPTION
Seems this pre-starting of request manages to time out in cases where there are a lot of changesets.
This can happen intermittently and sometimes seemingly randomly as sometimes code before last "await" will run slightly faster or slower

Possibly fixes all or many of those intermittent, large number of changesets or unknown error issues  