### PR TITLE
Bump @changesets/ghcommit to v1.4.0

### DIFF
--- a/.changeset/dry-bugs-applaud.md
+++ b/.changeset/dry-bugs-applaud.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": patch
+---
+
+Bump @changesets/ghcommit to v1.4.0, which fixes an issue running this action in monorepos with commitMode: github-api

--- a/.changeset/dry-bugs-applaud.md
+++ b/.changeset/dry-bugs-applaud.md
@@ -2,4 +2,4 @@
 "@changesets/action": patch
 ---
 
-Bump @changesets/ghcommit to v1.4.0, which fixes an issue running this action in monorepos with commitMode: github-api
+Bump `@changesets/ghcommit` to v1.4.0, which fixes an issue running this action in monorepos with `commitMode: github-api`

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@actions/core": "^1.10.0",
     "@actions/exec": "^1.1.1",
     "@actions/github": "^5.1.1",
-    "@changesets/ghcommit": "1.3.0",
+    "@changesets/ghcommit": "1.4.0",
     "@changesets/pre": "^1.0.9",
     "@changesets/read": "^0.5.3",
     "@manypkg/get-packages": "^1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1139,10 +1139,10 @@
   resolved "https://registry.yarnpkg.com/@changesets/get-version-range-type/-/get-version-range-type-0.3.2.tgz#8131a99035edd11aa7a44c341cbb05e668618c67"
   integrity sha512-SVqwYs5pULYjYT4op21F2pVbcrca4qA/bAA3FmFXKMN7Y+HcO8sbZUTx3TAy2VXulP2FACd1aC7f2nTuqSPbqg==
 
-"@changesets/ghcommit@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@changesets/ghcommit/-/ghcommit-1.3.0.tgz#8978eac4d5c2d4dc63865eeac00bc5922db7c0f3"
-  integrity sha512-Bbg4NlEqVWnykX12XlHw8V1JV/xdAJvuai3eEd7pPMiHT9k4n9FQyPdKs6ww1zooM0Xrjy0CC2INGtD8vKkc1Q==
+"@changesets/ghcommit@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@changesets/ghcommit/-/ghcommit-1.4.0.tgz#61a8bcdad1e78140ad69b6c6980e9c82471c8993"
+  integrity sha512-gG4QZsMwply4wFxqjfO7oI70lAb579zRbKB2EgjkVo+olWzXvmcQb52zkLpL3L9+QrAGD0QP8fNER9Wn3CmcHw==
   dependencies:
     isomorphic-git "^1.27.1"
 


### PR DESCRIPTION
Fixes the issue with`commitMode: github-api` in monorepos.

Closes #469 