### PR TITLE
Make git add work consistently with subdirectories

### DIFF
--- a/.changeset/itchy-eyes-look.md
+++ b/.changeset/itchy-eyes-look.md
@@ -1,0 +1,8 @@
+---
+"@changesets/action": patch
+---
+
+Make git add work consistently with subdirectories
+
+Ensure that when running the action from a subdirectory of a repository,
+only the files from that directory are added, regardless of `commitMode`.

--- a/src/git.ts
+++ b/src/git.ts
@@ -4,11 +4,11 @@ import * as github from "@actions/github";
 import { commitChangesFromRepo } from "@changesets/ghcommit/git";
 import { Octokit } from "./octokit";
 
-type ExecOptions = {
+type GitOptions = {
   cwd: string;
-}
+};
 
-const push = async (branch: string, options: ExecOptions) => {
+const push = async (branch: string, options: GitOptions) => {
   await exec(
     "git",
     ["push", "origin", `HEAD:${branch}`, "--force"].filter<string>(
@@ -20,7 +20,7 @@ const push = async (branch: string, options: ExecOptions) => {
 
 const switchToMaybeExistingBranch = async (
   branch: string,
-  options: ExecOptions
+  options: GitOptions
 ) => {
   let { stderr } = await getExecOutput("git", ["checkout", branch], {
     ignoreReturnCode: true,
@@ -34,16 +34,16 @@ const switchToMaybeExistingBranch = async (
   }
 };
 
-const reset = async (pathSpec: string, options: ExecOptions) => {
+const reset = async (pathSpec: string, options: GitOptions) => {
   await exec("git", ["reset", `--hard`, pathSpec], options);
 };
 
-const commitAll = async (message: string, options: ExecOptions) => {
+const commitAll = async (message: string, options: GitOptions) => {
   await exec("git", ["add", "."], options);
   await exec("git", ["commit", "-m", message], options);
 };
 
-const checkIfClean = async (options: ExecOptions): Promise<boolean> => {
+const checkIfClean = async (options: GitOptions): Promise<boolean> => {
   const { stdout } = await getExecOutput(
     "git",
     ["status", "--porcelain"],

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,8 +1,12 @@
 import * as core from "@actions/core";
-import { exec, ExecOptions, getExecOutput } from "@actions/exec";
+import { exec, getExecOutput } from "@actions/exec";
 import * as github from "@actions/github";
 import { commitChangesFromRepo } from "@changesets/ghcommit/git";
 import { Octokit } from "./octokit";
+
+type ExecOptions = {
+  cwd: string;
+}
 
 const push = async (branch: string, options: ExecOptions) => {
   await exec(

--- a/src/git.ts
+++ b/src/git.ts
@@ -9,13 +9,7 @@ type GitOptions = {
 };
 
 const push = async (branch: string, options: GitOptions) => {
-  await exec(
-    "git",
-    ["push", "origin", `HEAD:${branch}`, "--force"].filter<string>(
-      Boolean as any
-    ),
-    options
-  );
+  await exec("git", ["push", "origin", `HEAD:${branch}`, "--force"], options);
 };
 
 const switchToMaybeExistingBranch = async (

--- a/src/git.ts
+++ b/src/git.ts
@@ -87,6 +87,13 @@ export class Git {
 
   async pushChanges({ branch, message }: { branch: string; message: string }) {
     if (this.octokit) {
+      /** 
+       * Only add files form the current working directory
+       * 
+       * This will emulate the behavior of `git add .`,
+       * used in {@link commitAll}.
+       */
+      const addFromDirectory = process.cwd();
       return commitChangesFromRepo({
         octokit: this.octokit,
         ...github.context.repo,
@@ -95,6 +102,7 @@ export class Git {
         base: {
           commit: github.context.sha,
         },
+        addFromDirectory,
         force: true,
       });
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,11 +15,12 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
     return;
   }
 
-  const inputCwd = core.getInput("cwd");
+  const inputCwd = getOptionalInput("cwd");
   if (inputCwd) {
     core.info("changing directory to the one given as the input");
     process.chdir(inputCwd);
   }
+  const cwd = inputCwd || process.cwd();
 
   const octokit = setupOctokit(githubToken);
   const commitMode = getOptionalInput("commitMode") ?? "git-cli";
@@ -27,7 +28,10 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
     core.setFailed(`Invalid commit mode: ${commitMode}`);
     return;
   }
-  const git = new Git(commitMode === "github-api" ? octokit : undefined);
+  const git = new Git({
+    octokit: commitMode === "github-api" ? octokit : undefined,
+    cwd
+  });
 
   let setupGitUser = core.getBooleanInput("setupGitUser");
 
@@ -100,6 +104,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
         git,
         octokit,
         createGithubReleases: core.getBooleanInput("createGithubReleases"),
+        cwd,
       });
 
       if (result.published) {

--- a/src/run.ts
+++ b/src/run.ts
@@ -66,7 +66,7 @@ type PublishOptions = {
   octokit: Octokit;
   createGithubReleases: boolean;
   git: Git;
-  cwd?: string;
+  cwd: string;
 };
 
 type PublishedPackage = { name: string; version: string };
@@ -85,7 +85,7 @@ export async function runPublish({
   git,
   octokit,
   createGithubReleases,
-  cwd = process.cwd(),
+  cwd,
 }: PublishOptions): Promise<PublishResult> {
   let [publishCommand, ...publishArgs] = script.split(/\s+/);
 


### PR DESCRIPTION
This is a follow-up from #471

Currently, depending on your `commitMode`, when running the action with `cwd` set to a subdirectory of a repo, the action will either:

- `git-cli`: add the files changed in the subdirectory only
- `github-api`: add files changed anywhere in the repository

This commit brings github-api in line with git-cli, so that it only adds files in the current working directory.

Related: https://github.com/changesets/ghcommit/issues/29