### PR TITLE
fix: create tags implicitly through release api

### DIFF
--- a/.changeset/nervous-eggs-bathe.md
+++ b/.changeset/nervous-eggs-bathe.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": minor
+---
+
+Reduce the number of API calls when releasing with `commitMode: github-api`

--- a/src/git.ts
+++ b/src/git.ts
@@ -77,16 +77,8 @@ export class Git {
 
   async pushTag(tag: string) {
     if (this.octokit) {
-      return this.octokit.rest.git
-        .createRef({
-          ...github.context.repo,
-          ref: `refs/tags/${tag}`,
-          sha: github.context.sha,
-        })
-        .catch((err) => {
-          // Assuming tag was manually pushed in custom publish script
-          core.warning(`Failed to create tag ${tag}: ${err.message}`);
-        });
+      // a tag will be created automatically when creating a release
+      return;
     }
     await exec("git", ["push", "origin", tag], { cwd: this.cwd });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
   }
   const git = new Git({
     octokit: commitMode === "github-api" ? octokit : undefined,
-    cwd
+    cwd,
   });
 
   let setupGitUser = core.getBooleanInput("setupGitUser");
@@ -104,6 +104,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
         git,
         octokit,
         createGithubReleases: core.getBooleanInput("createGithubReleases"),
+        commitMode,
         cwd,
       });
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -50,6 +50,7 @@ const createRelease = async (
   await octokit.rest.repos.createRelease({
     name: tagName,
     tag_name: tagName,
+    target_commitish: github.context.sha,
     body: changelogEntry.content,
     prerelease: pkg.packageJson.version.includes("-"),
     ...github.context.repo,


### PR DESCRIPTION
Uses `target_commitish` to create a tag when it doesn't exist.

From https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release
> Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Unused if the Git tag already exists. Default: the repository's default branch.

closes #474 