### PR TITLE
fix: use latest ghcommit and fix cwd for git-cli

### DIFF
--- a/.changeset/lemon-garlics-sell.md
+++ b/.changeset/lemon-garlics-sell.md
@@ -1,0 +1,9 @@
+---
+"@changesets/action": patch
+---
+
+fix: cwd now works again with relative paths and commitMode: git-cli
+
+v1.5.2 introduced a bug where specifying `cwd`
+when using the default `commitMode` would break things,
+as it tried to resolve the path twice.

--- a/.changeset/lemon-garlics-sell.md
+++ b/.changeset/lemon-garlics-sell.md
@@ -2,8 +2,4 @@
 "@changesets/action": patch
 ---
 
-fix: cwd now works again with relative paths and commitMode: git-cli
-
-v1.5.2 introduced a bug where specifying `cwd`
-when using the default `commitMode` would break things,
-as it tried to resolve the path twice.
+Fixed situations in which `cwd` was specified as a relative path and used with (default) `commitMode: git-cli`

--- a/.changeset/sour-elephants-switch.md
+++ b/.changeset/sour-elephants-switch.md
@@ -1,7 +1,2 @@
 ---
-"@changesets/action": patch
 ---
-
-Update @changesets/ghcommit, and avoid calling `process.chdir()`
-
-fixes #475

--- a/.changeset/sour-elephants-switch.md
+++ b/.changeset/sour-elephants-switch.md
@@ -1,0 +1,7 @@
+---
+"@changesets/action": patch
+---
+
+Update @changesets/ghcommit, and avoid calling `process.chdir()`
+
+fixes #475

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@actions/core": "^1.11.1",
     "@actions/exec": "^1.1.1",
     "@actions/github": "^6.0.1",
-    "@changesets/ghcommit": "1.4.0",
+    "@changesets/ghcommit": "^2.0.0",
     "@changesets/pre": "^1.0.9",
     "@changesets/read": "^0.5.3",
     "@manypkg/get-packages": "^1.1.3",

--- a/src/git.ts
+++ b/src/git.ts
@@ -117,7 +117,7 @@ export class Git {
         base: {
           commit: github.context.sha,
         },
-        addFromDirectory,
+        cwd: this.cwd,
         force: true,
       });
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { Git } from "./git";
 import { setupOctokit } from "./octokit";
 import readChangesetState from "./readChangesetState";
 import { runPublish, runVersion } from "./run";
+import { resolve } from "path";
 
 const getOptionalInput = (name: string) => core.getInput(name) || undefined;
 
@@ -16,11 +17,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
   }
 
   const inputCwd = getOptionalInput("cwd");
-  if (inputCwd) {
-    core.info("changing directory to the one given as the input");
-    process.chdir(inputCwd);
-  }
-  const cwd = inputCwd || process.cwd();
+  const cwd = inputCwd ? resolve(inputCwd) : process.cwd();
 
   const octokit = setupOctokit(githubToken);
   const commitMode = getOptionalInput("commitMode") ?? "git-cli";

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,8 +17,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
     return;
   }
 
-  const inputCwd = getOptionalInput("cwd");
-  const cwd = inputCwd ? path.resolve(inputCwd) : process.cwd();
+  const cwd = path.resolve(getOptionalInput("cwd") ?? "");
 
   const octokit = setupOctokit(githubToken);
   const commitMode = getOptionalInput("commitMode") ?? "git-cli";

--- a/yarn.lock
+++ b/yarn.lock
@@ -219,10 +219,10 @@
   resolved "https://registry.yarnpkg.com/@changesets/get-version-range-type/-/get-version-range-type-0.3.2.tgz#8131a99035edd11aa7a44c341cbb05e668618c67"
   integrity sha512-SVqwYs5pULYjYT4op21F2pVbcrca4qA/bAA3FmFXKMN7Y+HcO8sbZUTx3TAy2VXulP2FACd1aC7f2nTuqSPbqg==
 
-"@changesets/ghcommit@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@changesets/ghcommit/-/ghcommit-1.4.0.tgz#61a8bcdad1e78140ad69b6c6980e9c82471c8993"
-  integrity sha512-gG4QZsMwply4wFxqjfO7oI70lAb579zRbKB2EgjkVo+olWzXvmcQb52zkLpL3L9+QrAGD0QP8fNER9Wn3CmcHw==
+"@changesets/ghcommit@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@changesets/ghcommit/-/ghcommit-2.0.0.tgz#a3d8f733ad7ec9bb1f17c7dc0b64c3f62636305f"
+  integrity sha512-UFS7mCjh3B8KfiDQi6JbZNDoANdTqLgBKHCwMASZ25A3yfxaFVKURGzwdMdlcYx5k6dHN1igDHzgXuwOyZ9xKg==
   dependencies:
     isomorphic-git "^1.27.1"
 


### PR DESCRIPTION
- `cwd` was not working correctly when commitMode was set to `git-cli`, as it was attempting to resolve the `cwd` twice. (This problem only occured when specifying a relative path for `cwd`.)
- Update `ghcommit`, and avoid calling `process.chdir()` to change the working directory. Instead, we now pass the `cwd` option everywhere.

fixes #475