### PR TITLE
Fix PRs sometimes not getting reopened

### DIFF
--- a/.changeset/big-cougars-mate.md
+++ b/.changeset/big-cougars-mate.md
@@ -1,0 +1,11 @@
+---
+"@changesets/action": patch
+---
+
+Fix PRs sometimes not getting reopened (with `commitMode: github-api`)
+
+There was a race-condition that means sometimes existing PRs would not be found,
+and new PRs would be opened. This has now been fixed by fetching existing PRs
+before making any changes.
+
+fixes #487

--- a/.changeset/big-cougars-mate.md
+++ b/.changeset/big-cougars-mate.md
@@ -2,10 +2,9 @@
 "@changesets/action": patch
 ---
 
-Fix PRs sometimes not getting reopened (with `commitMode: github-api`)
+Fix PRs sometimes not getting reopened with `commitMode: github-api`
 
 There was a race-condition that means sometimes existing PRs would not be found,
 and new PRs would be opened. This has now been fixed by fetching existing PRs
 before making any changes.
 
-fixes #487

--- a/src/run.ts
+++ b/src/run.ts
@@ -314,15 +314,22 @@ export async function runVersion({
     !!preState ? ` (${preState.tag})` : ""
   }`;
 
-  await git.pushChanges({ branch: versionBranch, message: finalCommitMessage });
-
-  let existingPullRequests = await octokit.rest.pulls.list({
+  /**
+   * Fetch any existing pull requests that are open against the branch,
+   * before we push any changes that may inadvertently close the existing PRs.
+   * 
+   * (`@changesets/ghcommit` has to reset the branch to the same commit as the base,
+   * which GitHub will then react to by closing the PRs)
+   */
+  const existingPullRequests = await octokit.rest.pulls.list({
     ...github.context.repo,
     state: "open",
     head: `${github.context.repo.owner}:${versionBranch}`,
     base: branch,
   });
-  core.info(JSON.stringify(existingPullRequests.data, null, 2));
+  core.info(`Existing pull requests: ${JSON.stringify(existingPullRequests.data, null, 2)}`);
+
+  await git.pushChanges({ branch: versionBranch, message: finalCommitMessage });
 
   const changedPackagesInfo = (await changedPackagesInfoPromises)
     .filter((x) => x)


### PR DESCRIPTION
There was a race-condition that means sometimes existing PRs would not be found, and new PRs would be opened. This has now been fixed by fetching existing PRs before making any changes.

fixes #487