### PR TITLE
Add missing `outputs` in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ This action for [Changesets](https://github.com/changesets/changesets) creates a
 
 - published - A boolean value to indicate whether a publishing has happened or not
 - publishedPackages - A JSON array to present the published packages. The format is `[{"name": "@xx/xx", "version": "1.2.0"}, {"name": "@xx/xy", "version": "0.8.9"}]`
+- hasChangesets - A boolean about whether there were changesets. Useful if you want to create your own publishing functionality.
+- pullRequestNumber - The pull request number that was created or updated.
 
 ### Example workflow:
 


### PR DESCRIPTION
I needed to get the PR number, according the the docs it's not exposed, but after looking at the code I found out that it is.

I assumed it would be nice to include it in the docs for the next person

maybe we can add some kind of automation for that