### PR TITLE
fix: tags in `git-cli` commit mode

### DIFF
--- a/.changeset/cold-dryers-march.md
+++ b/.changeset/cold-dryers-march.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": patch
+---
+
+Fix custom publish scripts that don't create tags locally

--- a/.changeset/three-women-brush.md
+++ b/.changeset/three-women-brush.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": patch
+---
+
+Fix tags not pushing when `createGithubReleases` is false

--- a/src/git.ts
+++ b/src/git.ts
@@ -88,7 +88,10 @@ export class Git {
           core.warning(`Failed to create tag ${tag}: ${err.message}`);
         });
     }
-    await exec("git", ["push", "origin", tag], { cwd: this.cwd });
+    await exec("git", ["push", "origin", tag], {
+      cwd: this.cwd,
+      ignoreReturnCode: true,
+    });
   }
 
   async prepareBranch(branch: string) {


### PR DESCRIPTION
closes #465 

Fixes both cases described in the issue:

- Custom `publish` script that does not create tag errors

  This case happens when you have a custom release script, instead of running `changeset tag` or `changeset version`, that does not create tags locally, but only prints `New version:` to force changeset to still create a release (which would implicitly create a tag as well). Not sure how they ended up with that solution though, maybe it predates the `changeset tag` command?

  Fixed by passing `ignoreReturnCode: true` when pushing the tag. Not sure if this can have some pitfalls if an error is returned for other reasons though.

- `createGithubReleases: false` does not push tags

  In #391, pushing tags was moved from always happening, to only happening if `createGithubReleases` is true. https://github.com/changesets/action/pull/391/files#diff-69c9100f2a3041c22e8fddf77d13fd7eb1aa42a8a200aa35a81ea589c135e66aL133

  Fixed by moving the `createGithubReleases` if-statement to only affect actually creating a github release.