### PR TITLE
Feature: Customize PR branch name suffix

### DIFF
--- a/.changeset/good-mice-brake.md
+++ b/.changeset/good-mice-brake.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": patch
+---
+
+Allow customize branch name

--- a/.changeset/good-mice-brake.md
+++ b/.changeset/good-mice-brake.md
@@ -1,5 +1,5 @@
 ---
-"@changesets/action": patch
+"@changesets/action": minor
 ---
 
-Allow customize branch name
+Allow a custom PR branch name with prBranchSuffix

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This action for [Changesets](https://github.com/changesets/changesets) creates a
 - createGithubReleases - A boolean value to indicate whether to create Github releases after `publish` or not. Default to `true`
 - commitMode - Specifies the commit mode. Use `"git-cli"` to push changes using the Git CLI, or `"github-api"` to push changes via the GitHub API. When using `"github-api"`, all commits and tags are GPG-signed and attributed to the user or app who owns the `GITHUB_TOKEN`. Default to `git-cli`.
 - cwd - Changes node's `process.cwd()` if the project is not located on the root. Default to `process.cwd()`
+- branch - Sets the branch in which the action will run. Default to `github.ref_name`
+- prBranchSuffix - The suffix to include after `changeset-release/` in the PR branch. Defaults to the `branch` variable.
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,9 @@ inputs:
       or app who owns the GITHUB_TOKEN.
     required: false
     default: "git-cli"
+  branchName:
+    description: Sets the branch name for the pull request. Default to `changeset-release/{{$github.ref_name}}`
+    required: false
   branch:
     description: Sets the branch in which the action will run. Default to `github.ref_name` if not provided
     required: false

--- a/action.yml
+++ b/action.yml
@@ -36,8 +36,8 @@ inputs:
       or app who owns the GITHUB_TOKEN.
     required: false
     default: "git-cli"
-  branchName:
-    description: Sets the branch name for the pull request. Default to `changeset-release/{{$github.ref_name}}`
+  prBranchSuffix:
+    description: The suffix to include after `changeset-release/` in the PR branch. Defaults to the `branch` variable.
     required: false
   branch:
     description: Sets the branch in which the action will run. Default to `github.ref_name` if not provided

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,7 +126,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
         commitMessage: getOptionalInput("commit"),
         hasPublishScript,
         branch: getOptionalInput("branch"),
-        branchName: getOptionalInput("branchName"),
+        prBranchSuffix: getOptionalInput("prBranchSuffix"),
       });
 
       core.setOutput("pullRequestNumber", String(pullRequestNumber));

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,6 +126,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
         commitMessage: getOptionalInput("commit"),
         hasPublishScript,
         branch: getOptionalInput("branch"),
+        branchName: getOptionalInput("branchName"),
       });
 
       core.setOutput("pullRequestNumber", String(pullRequestNumber));

--- a/src/run.ts
+++ b/src/run.ts
@@ -20,7 +20,9 @@ import {
 
 const require = createRequire(import.meta.url);
 
-// GitHub Issues/PRs messages have a max size limit on the
+// GitHub Issues/PRs messages have a max size limit on th
+
+
 // message body payload.
 // `body is too long (maximum is 65536 characters)`.
 // To avoid that, we ensure to cap the message to 60k chars.
@@ -257,6 +259,7 @@ type VersionOptions = {
   hasPublishScript?: boolean;
   prBodyMaxCharacters?: number;
   branch?: string;
+  branchName?: string;
 };
 
 type RunVersionResult = {
@@ -273,8 +276,9 @@ export async function runVersion({
   hasPublishScript = false,
   prBodyMaxCharacters = MAX_CHARACTERS_PER_MESSAGE,
   branch = github.context.ref.replace("refs/heads/", ""),
+  branchName
 }: VersionOptions): Promise<RunVersionResult> {
-  let versionBranch = `changeset-release/${branch}`;
+  let versionBranch = branchName ?? `changeset-release/${branch}`;
 
   let { preState } = await readChangesetState(cwd);
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -257,7 +257,7 @@ type VersionOptions = {
   hasPublishScript?: boolean;
   prBodyMaxCharacters?: number;
   branch?: string;
-  branchName?: string;
+  prBranchSuffix?: string;
 };
 
 type RunVersionResult = {
@@ -274,9 +274,9 @@ export async function runVersion({
   hasPublishScript = false,
   prBodyMaxCharacters = MAX_CHARACTERS_PER_MESSAGE,
   branch = github.context.ref.replace("refs/heads/", ""),
-  branchName
+  prBranchSuffix,
 }: VersionOptions): Promise<RunVersionResult> {
-  let versionBranch = branchName ?? `changeset-release/${branch}`;
+  let versionBranch = `changeset-release/${prBranchSuffix ?? branch}`;
 
   let { preState } = await readChangesetState(cwd);
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -20,9 +20,7 @@ import {
 
 const require = createRequire(import.meta.url);
 
-// GitHub Issues/PRs messages have a max size limit on th
-
-
+// GitHub Issues/PRs messages have a max size limit on the
 // message body payload.
 // `body is too long (maximum is 65536 characters)`.
 // To avoid that, we ensure to cap the message to 60k chars.


### PR DESCRIPTION
Fixes #184
Follow up to stale PR https://github.com/changesets/action/pull/370/ with a slightly different approach.

Adds input `prBranchSuffix`

This feature allows the user to customize the suffix of the branch name that gets created for the versioning Pull Request. By default this would otherwise be `changeset-release/${{ github.ref_name }}`, but this doesn't work well for monorepos that have multiple uses of `changesets/action` within them, which would otherwise overwrite each other when pushing to `changeset-release/main`. With this change, monorepo users can have multiple workflows that specify different suffixes so that multiple versioning pull requests can be opened simultaneously.

For example:

```yml
# .github/workflows/version-foo.yml
on:
  push:
    branches: [main]
    paths: [foo/packages/**]
jobs:
  changesets:
    steps:
      - name: Version
        uses: changesets/action
        with:
          cwd: foo/packages
          title: Version foo
          prBranchSuffix: foo
          
# .github/workflows/version-bar.yml
on:
  push:
    branches: [main]
    paths: [bar/packages/**]
jobs:
  changesets:
    steps:
      - name: Version
        uses: changesets/action
        with:
          cwd: bar/packages
          title: Version bar
          prBranchSuffix: bar
```

I've attempted to address the feedback that had been left on the previous PR, and sought a route that uses a "suffix" approach instead of overriding the `changeset-release/*` prefixing.

