### PR TITLE
Support project as well as user `.npmrc` files.

### DIFF
--- a/.changeset/clear-cycles-smash.md
+++ b/.changeset/clear-cycles-smash.md
@@ -1,0 +1,9 @@
+---
+"@changesets/action": minor
+---
+
+Support project as well as user `.npmrc` files.
+
+See https://github.com/changesets/action/issues/89.
+
+Checks for a project local `.npmrc` before the user `.npmrc`, which avoids potentially misleading log messages (not finding a user `.npmrc` is not a problem if there's a project one) and unecessarily generating a user `.npmrc`.

--- a/README.md
+++ b/README.md
@@ -104,13 +104,13 @@ jobs:
         run: my-slack-bot send-notification --message "A new version of ${GITHUB_REPOSITORY} was published!"
 ```
 
-By default the GitHub Action creates a `.npmrc` file with the following content:
+By default the GitHub Action creates a `.npmrc` file with the following content to the user `$HOME` `.npmrc`:
 
 ```
 //registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}
 ```
 
-However, if a `.npmrc` file is found, the GitHub Action does not recreate the file. This is useful if you need to configure the `.npmrc` file on your own.
+However, if either a project or user `.npmrc` file is found, the GitHub Action does not recreate the file. This is useful if you need to configure the `.npmrc` file on your own.
 For example, you can add a step before running the Changesets GitHub Action:
 
 ```yml


### PR DESCRIPTION
See https://github.com/changesets/action/issues/89.

Checks for a project local `.npmrc` before the user `.npmrc`, which avoids potentially misleading log messages (not finding a user `.npmrc` is not a problem if there's a project one) and unecessarily generating a user `.npmrc`.
