### PR TITLE
feat: new `body` option for custom PR body, with placeholders

### DIFF
--- a/.changeset/afraid-otters-go.md
+++ b/.changeset/afraid-otters-go.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": minor
+---
+
+Added `body` option for custom PR body with default placeholders

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This action for [Changesets](https://github.com/changesets/changesets) creates a
 - version - The command to update version, edit CHANGELOG, read and delete changesets. Default to `changeset version` if not provided
 - commit - The commit message to use. Default to `Version Packages`
 - title - The pull request title. Default to `Version Packages`
+- body - The pull request body. Default to the current implementation. Available placeholders: `<!-- header -->`, `<!-- prestate -->`, `<!-- releasesHeading -->`, `<!-- body -->`
 - setupGitUser - Sets up the git user for commits as `"github-actions[bot]"`. Default to `true`
 - createGithubReleases - A boolean value to indicate whether to create Github releases after `publish` or not. Default to `true`
 - commitMode - Specifies the commit mode. Use `"git-cli"` to push changes using the Git CLI, or `"github-api"` to push changes via the GitHub API. When using `"github-api"`, all commits and tags are GPG-signed and attributed to the user or app who owns the `GITHUB_TOKEN`. Default to `git-cli`.

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
   title:
     description: The pull request title. Default to `Version Packages`
     required: false
+  body:
+    description: The pull request body. Default to the current implementation. Available placeholders: `<!-- header -->`, `<!-- prestate -->`, `<!-- releasesHeading -->`, `<!-- body -->`
+    required: false
   setupGitUser:
     description: Sets up the git user for commits as `"github-actions[bot]"`. Default to `true`
     required: false

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,6 +123,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
         git,
         octokit,
         prTitle: getOptionalInput("title"),
+        prBody: getOptionalInput("body"),
         commitMessage: getOptionalInput("commit"),
         hasPublishScript,
         branch: getOptionalInput("branch"),

--- a/src/run.ts
+++ b/src/run.ts
@@ -188,6 +188,7 @@ type GetMessageOptions = {
     header: string;
   }[];
   prBodyMaxCharacters: number;
+  prBody?: string;
   preState?: PreState;
 };
 
@@ -196,6 +197,7 @@ export async function getVersionPrBody({
   preState,
   changedPackagesInfo,
   prBodyMaxCharacters,
+  prBody,
   branch,
 }: GetMessageOptions) {
   let messageHeader = `This PR was opened by the [Changesets release](https://github.com/changesets/action) GitHub action. When you're ready to do a release, you can merge this and ${
@@ -214,34 +216,42 @@ export async function getVersionPrBody({
     : "";
   let messageReleasesHeading = `# Releases`;
 
-  let fullMessage = [
-    messageHeader,
-    messagePrestate,
-    messageReleasesHeading,
+  function useOrBuildTemplate(lines: string[]) {
+    if (!prBody) {
+      return [
+        messageHeader,
+        messagePrestate,
+        messageReleasesHeading,
+        ...lines,
+      ].join('\n');
+    }
+
+    return prBody
+      .replace('<!-- header -->', messageHeader)
+      .replace('<!-- prestate -->', messagePrestate)
+      .replace('<!-- releasesHeading -->', messageReleasesHeading)
+      .replace('<!-- body -->', lines.join('\n'));
+  }
+
+  let fullMessage = useOrBuildTemplate([
     ...changedPackagesInfo.map((info) => `${info.header}\n\n${info.content}`),
-  ].join("\n");
+  ]);
 
   // Check that the message does not exceed the size limit.
   // If not, omit the changelog entries of each package.
   if (fullMessage.length > prBodyMaxCharacters) {
-    fullMessage = [
-      messageHeader,
-      messagePrestate,
-      messageReleasesHeading,
+    fullMessage = useOrBuildTemplate([
       `\n> The changelog information of each package has been omitted from this message, as the content exceeds the size limit.\n`,
       ...changedPackagesInfo.map((info) => `${info.header}\n\n`),
-    ].join("\n");
+    ]);
   }
 
   // Check (again) that the message is within the size limit.
   // If not, omit all release content this time.
   if (fullMessage.length > prBodyMaxCharacters) {
-    fullMessage = [
-      messageHeader,
-      messagePrestate,
-      messageReleasesHeading,
+    fullMessage = useOrBuildTemplate([
       `\n> All release information have been omitted from this message, as the content exceeds the size limit.`,
-    ].join("\n");
+    ]);
   }
 
   return fullMessage;
@@ -253,6 +263,7 @@ type VersionOptions = {
   octokit: Octokit;
   cwd?: string;
   prTitle?: string;
+  prBody?: string;
   commitMessage?: string;
   hasPublishScript?: boolean;
   prBodyMaxCharacters?: number;
@@ -269,6 +280,7 @@ export async function runVersion({
   octokit,
   cwd = process.cwd(),
   prTitle = "Version Packages",
+  prBody,
   commitMessage = "Version Packages",
   hasPublishScript = false,
   prBodyMaxCharacters = MAX_CHARACTERS_PER_MESSAGE,
@@ -348,12 +360,13 @@ export async function runVersion({
     .filter((x) => x)
     .sort(sortTheThings);
 
-  let prBody = await getVersionPrBody({
+  prBody = await getVersionPrBody({
     hasPublishScript,
     preState,
     branch,
     changedPackagesInfo,
     prBodyMaxCharacters,
+    prBody,
   });
 
   if (existingPullRequests.data.length === 0) {


### PR DESCRIPTION
This PR adds new `body` option for customizing pull request body while still supporting default text-blocks via placeholders.

```yaml
      - name: Create Version Pull Request
        uses: changesets/action@v1
        with:
          body: '<!-- header --><!-- prestate --><!-- releasesHeading --><!-- body -->'
```

Fixes https://github.com/changesets/action/issues/65