### PR TITLE
Automatically use the GitHub-provided token to allow most users to avoid explicit `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` configuration

### DIFF
--- a/.changeset/quiet-vans-fail.md
+++ b/.changeset/quiet-vans-fail.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": minor
+---
+
+Automatically use the GitHub-provided token to allow most users to avoid explicit `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` configuration.

--- a/README.md
+++ b/README.md
@@ -54,8 +54,6 @@ jobs:
 
       - name: Create Release Pull Request
         uses: changesets/action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 #### With Publishing
@@ -95,7 +93,6 @@ jobs:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: yarn release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Send a Slack notification if a publish happens
@@ -156,8 +153,6 @@ jobs:
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish
         if: steps.changesets.outputs.hasChangesets == 'false'
@@ -202,8 +197,6 @@ jobs:
         with:
           # this expects you to have a npm script called version that runs some logic and then calls `changeset version`.
           version: yarn version
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 #### With Yarn 2 / Plug'n'Play

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,10 @@ runs:
   using: "node24"
   main: "dist/index.js"
 inputs:
+  github-token:
+    description: "The GitHub token to use for authentication. Defaults to the GitHub-provided token."
+    required: false
+    default: ${{ github.token }}
   publish:
     description: "The command to use to build and publish packages"
     required: false

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,9 @@ import { fileExists } from "./utils.ts";
 const getOptionalInput = (name: string) => core.getInput(name) || undefined;
 
 (async () => {
-  let githubToken = process.env.GITHUB_TOKEN;
+  // to maintain compatibility with workflows created before github-token input was introduced
+  // it's important to prefer the explicitly set GITHUB_TOKEN over the default token coming from github.token
+  let githubToken = process.env.GITHUB_TOKEN || core.getInput("github-token");
 
   if (!githubToken) {
     core.setFailed("Please add the GITHUB_TOKEN to the changesets action");
@@ -98,6 +100,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
 
       const result = await runPublish({
         script: publishScript,
+        githubToken,
         git,
         octokit,
         createGithubReleases: core.getBooleanInput("createGithubReleases"),
@@ -120,6 +123,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
       const octokit = setupOctokit(githubToken);
       const { pullRequestNumber } = await runVersion({
         script: getOptionalInput("version"),
+        githubToken,
         git,
         octokit,
         prTitle: getOptionalInput("title"),

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -82,6 +82,7 @@ describe("version", () => {
 
     await runVersion({
       octokit: setupOctokit("@@GITHUB_TOKEN"),
+      githubToken: "@@GITHUB_TOKEN",
       git: new Git({ cwd }),
       cwd,
     });
@@ -116,6 +117,7 @@ describe("version", () => {
 
     await runVersion({
       octokit: setupOctokit("@@GITHUB_TOKEN"),
+      githubToken: "@@GITHUB_TOKEN",
       git: new Git({ cwd }),
       cwd,
     });
@@ -150,6 +152,7 @@ describe("version", () => {
 
     await runVersion({
       octokit: setupOctokit("@@GITHUB_TOKEN"),
+      githubToken: "@@GITHUB_TOKEN",
       git: new Git({ cwd }),
       cwd,
     });
@@ -204,6 +207,7 @@ fluminis divesque vulnere aquis parce lapsis rabie si visa fulmineis.
 
     await runVersion({
       octokit: setupOctokit("@@GITHUB_TOKEN"),
+      githubToken: "@@GITHUB_TOKEN",
       git: new Git({ cwd }),
       cwd,
       prBodyMaxCharacters: 1000,
@@ -262,6 +266,7 @@ fluminis divesque vulnere aquis parce lapsis rabie si visa fulmineis.
 
     await runVersion({
       octokit: setupOctokit("@@GITHUB_TOKEN"),
+      githubToken: "@@GITHUB_TOKEN",
       git: new Git({ cwd }),
       cwd,
       prBodyMaxCharacters: 500,


### PR DESCRIPTION
closes https://github.com/changesets/action/issues/525

It feels a little bit off to even be able to do this implicitly but I don't see any scenarios in which one wouldn't like to pass this token to Changesets so I guess it's fine.