### PR TITLE
🐛 fix readChangesetState not respecting cwd input

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
     `machine github.com\nlogin github-actions[bot]\npassword ${githubToken}`
   );
 
-  let { changesets } = await readChangesetState();
+  let { changesets } = await readChangesetState(cwd);
 
   let publishScript = core.getInput("publish");
   let hasChangesets = changesets.length !== 0;


### PR DESCRIPTION
The cwd input was already used for Git operations but was missing when calling readChangesetState(), causing changesets to be read from the wrong directory in monorepo setups.