### PR TITLE
Fix PR not being reopened after force push with commitMode github-api

### DIFF
--- a/.changeset/fix-reopen-after-force-push.md
+++ b/.changeset/fix-reopen-after-force-push.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": patch
+---
+
+Fix PR not being reopened after force push when using `commitMode: "github-api"`

--- a/src/run.ts
+++ b/src/run.ts
@@ -431,6 +431,35 @@ export async function runVersion({
       body: prBody,
     });
 
+    // When using commitMode: "github-api", the force push closes the PR asynchronously.
+    // The state: OPEN in the mutation above may be a no-op if close propagation has not
+    // completed yet, so verify and reopen via REST until the PR is confirmed open.
+    if (git.octokit) {
+      const maxAttempts = 5;
+      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        const { data: currentPr } = await octokit.rest.pulls.get({
+          pull_number: pullRequest.number,
+          ...github.context.repo,
+        });
+        if (currentPr.state === "open") break;
+        if (attempt === maxAttempts) {
+          core.warning(
+            `PR #${pullRequest.number} could not be reopened after ${maxAttempts} attempts`
+          );
+          break;
+        }
+        core.info(
+          `PR #${pullRequest.number} is still closed, reopening (attempt ${attempt}/${maxAttempts - 1})...`
+        );
+        await octokit.rest.pulls.update({
+          pull_number: pullRequest.number,
+          state: "open",
+          ...github.context.repo,
+        });
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+      }
+    }
+
     return {
       pullRequestNumber: pullRequest.number,
     };


### PR DESCRIPTION
## Why

Fixes #615

Since v1.8.0, when using `commitMode: "github-api"`, existing Version Packages PRs are sometimes not reopened after being closed by a force push.

When using `commitMode: "github-api"`, the action force-pushes the branch via the GitHub API, which causes GitHub to close any open PRs targeting that branch. The subsequent GraphQL mutation with `state: OPEN` could be a no-op if GitHub's close propagation had not completed yet, leaving the PR permanently closed.

## What

After the GraphQL update, verify the PR is actually open and retry reopening via the REST API (up to 5 times, with 3s intervals) until confirmed. This only runs when `commitMode: "github-api"` is in use (`git.octokit !== null`).

## Notes

- Tested against a production repository that was consistently hitting this issue
