### PR TITLE
Migrate to oxfmt

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "printWidth": 80,
+  "trailingComma": "es5"
+}

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,7 +1,6 @@
 {
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
   "printWidth": 80,
-  "trailingComma": "es5",
   "sortImports": {
     "newlinesBetween": false
   }

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,5 +1,8 @@
 {
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
   "printWidth": 80,
-  "trailingComma": "es5"
+  "trailingComma": "es5",
+  "sortImports": {
+    "newlinesBetween": false
+  }
 }

--- a/__fixtures__/ignored-package/.changeset/config.json
+++ b/__fixtures__/ignored-package/.changeset/config.json
@@ -1,6 +1,4 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@1.3.0/schema.json",
-  "ignore": [
-    "changesets-dev-ignored-package-pkg-a"
-  ]
+  "ignore": ["changesets-dev-ignored-package-pkg-a"]
 }

--- a/__fixtures__/ignored-package/package.json
+++ b/__fixtures__/ignored-package/package.json
@@ -1,7 +1,7 @@
 {
-  "private": true,
   "name": "ignored-package",
   "version": "1.0.0",
+  "private": true,
   "workspaces": [
     "packages/*"
   ]

--- a/__fixtures__/simple-project/package.json
+++ b/__fixtures__/simple-project/package.json
@@ -1,7 +1,7 @@
 {
-  "private": true,
   "name": "simple-project",
   "version": "1.0.0",
+  "private": true,
   "workspaces": [
     "packages/*"
   ]

--- a/package.json
+++ b/package.json
@@ -1,40 +1,20 @@
 {
   "name": "@changesets/action",
   "version": "1.8.0",
-  "main": "dist/index.js",
-  "type": "module",
   "license": "MIT",
-  "devDependencies": {
-    "@changesets/changelog-github": "^0.5.1",
-    "@changesets/cli": "^2.29.3",
-    "@changesets/types": "^6.1.0",
-    "@changesets/write": "^0.4.0",
-    "@rollup/plugin-commonjs": "^28.0.3",
-    "@rollup/plugin-json": "^6.1.0",
-    "@rollup/plugin-node-resolve": "^16.0.1",
-    "@rollup/plugin-terser": "^0.4.4",
-    "@types/node": "^24.12.2",
-    "@types/semver": "^7.5.0",
-    "builtin-modules": "^5.0.0",
-    "esbuild": "^0.25.4",
-    "fixturez": "^1.1.0",
-    "prettier": "^2.0.5",
-    "rollup": "^4.40.2",
-    "typescript": "^5.8.3",
-    "vitest": "^3.1.3"
-  },
+  "type": "module",
+  "main": "dist/index.js",
   "scripts": {
     "build": "rollup -c",
     "test": "vitest",
     "test:watch": "pnpm test --watch",
     "typecheck": "tsc",
+    "format": "oxfmt --check",
+    "format:fix": "oxfmt",
     "changeset": "changeset",
     "bump": "node --experimental-strip-types ./scripts/bump.ts",
     "release": "node --experimental-strip-types ./scripts/release.ts",
     "release:pr": "node --experimental-strip-types ./scripts/release-pr.ts"
-  },
-  "engines": {
-    "node": ">= 24"
   },
   "dependencies": {
     "@actions/core": "^3.0.1",
@@ -53,12 +33,27 @@
     "semver": "^7.5.3",
     "unified": "^8.3.2"
   },
-  "pnpm": {
-    "overrides": {
-      "trim": "^0.0.3",
-      "y18n": "^4.0.1"
-    }
+  "devDependencies": {
+    "@changesets/changelog-github": "^0.5.1",
+    "@changesets/cli": "^2.29.3",
+    "@changesets/types": "^6.1.0",
+    "@changesets/write": "^0.4.0",
+    "@rollup/plugin-commonjs": "^28.0.3",
+    "@rollup/plugin-json": "^6.1.0",
+    "@rollup/plugin-node-resolve": "^16.0.1",
+    "@rollup/plugin-terser": "^0.4.4",
+    "@types/node": "^24.12.2",
+    "@types/semver": "^7.5.0",
+    "builtin-modules": "^5.0.0",
+    "esbuild": "^0.25.4",
+    "fixturez": "^1.1.0",
+    "oxfmt": "^0.48.0",
+    "rollup": "^4.40.2",
+    "typescript": "^5.8.3",
+    "vitest": "^3.1.3"
   },
-  "prettier": {},
+  "engines": {
+    "node": ">=24"
+  },
   "packageManager": "pnpm@11.1.1+sha512.d1fdf5f73c617b64fa1a56a81c3c8dfe0e966e33a6010aa256b517ae77be21d93e05affc0de1a83b0e4f29d569f68b446ae8f068cd7247c0bb3df0fb4d7bdf9a"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,9 +94,9 @@ importers:
       fixturez:
         specifier: ^1.1.0
         version: 1.1.0
-      prettier:
-        specifier: ^2.0.5
-        version: 2.8.8
+      oxfmt:
+        specifier: ^0.48.0
+        version: 0.48.0
       rollup:
         specifier: ^4.40.2
         version: 4.60.2
@@ -597,6 +597,128 @@ packages:
 
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
+
+  '@oxfmt/binding-android-arm-eabi@0.48.0':
+    resolution: {integrity: sha512-uwqk+/KhQvBIpULD8SMM/zAafMRC/+DV/xsEQjkkIsJ/kLmEI/2bxonVowcYTiXqqZ/a0FEW8DPkZY3VvwELDA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxfmt/binding-android-arm64@0.48.0':
+    resolution: {integrity: sha512-VUCiKuXK5+McVssgHEJdrcGK7hRJzrRb36zm9/jwzMholyYt4BgXhw5Nm1V1DX6Ce717Zi/1jk432b/tgmQgtQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxfmt/binding-darwin-arm64@0.48.0':
+    resolution: {integrity: sha512-IkKp8rnIyQLW6Jt+6jragCbUVYSayk55lapiprLjIVvt4NczLyO/nwX2GgefLQ5iaBdfS8UEAFgCs/pLO6Cl0w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxfmt/binding-darwin-x64@0.48.0':
+    resolution: {integrity: sha512-+aFuhsGIuvnoOjXyKVHMhPKJZR1kQkAl8QyrKoMlA7yJsSTC3N0Asl53La8TChSHhW8epToQ/Q0nvLmEmfNmLg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxfmt/binding-freebsd-x64@0.48.0':
+    resolution: {integrity: sha512-fbqzQL8FjI9gGnktI7RIo0dksDziTAYBy7xlI7jU7eID5fxLF/25fS4Xj6GydD8Y5oWHL83U4NK160QaOAxtyg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.48.0':
+    resolution: {integrity: sha512-hn4i0zhAyTiB3ZHjQfYUZkDvrbVkohw1S7pySWxWUoZ87HnkDoTFThj7QTxk40hNPOTUP0vHbPRNamFIv1HBJQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.48.0':
+    resolution: {integrity: sha512-R4WBD9qF3QM9hqgdAa+fBGXmquTvDUujrPQ36t2Sjk8RPOSKGHDeN7l/khr10hqbQaOq9KCgPHG9ubNET/X/RQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-gnu@0.48.0':
+    resolution: {integrity: sha512-5bVdwSwlm1M8wbYCorLOxWxUBw/8tBvHYyQNIfwWVPwOJaj5vg1APSGJQVpwJfV5VNE9PSrR91UKEpoNwHhqUA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-arm64-musl@0.48.0':
+    resolution: {integrity: sha512-vCS3Fk7gFslTqE1lUE2IlroyVV7u/9SmMA/uBqDoshuck2psGWcjW0ePyPZI3rM3+qtf2pDaMVIKMHozraifuw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.48.0':
+    resolution: {integrity: sha512-gKtfFfueUClXDumyoHUbymqRf7prHejOOyzJK0eIJn93GF9JBdFHdo60TM1ZBHxkEwZvjuOgHmKtneKbEOc/Eg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.48.0':
+    resolution: {integrity: sha512-SYt0UhOvZD/UwZz9sXq6J2uAw8o24f5VZpLB2DH01f6MevshmlgakQlZe2lwek2sZJkd07eLu7mZa0g7yeiw7Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-musl@0.48.0':
+    resolution: {integrity: sha512-JLbrwck2AopG4ud/XklZO5N+qxGC7cS7ROvXZVNfx0MCLDDL2kGOLvzuWORkVjnjAM0CMAfIMU2zNBtQbM+4dw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-s390x-gnu@0.48.0':
+    resolution: {integrity: sha512-mdxt5L8OQLxkQH+JVpdC/lknZNe0lX4hlO3d8+xvw2wToo+iDrid9tiGOd5bmHfUVd5wVhrUry0qlu5vq66NkQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-gnu@0.48.0':
+    resolution: {integrity: sha512-oEz1BQwMrV7OMEFx/3VPDU3n9TM0AnxpktDYXjEg5i6nTX87wo18wSfBvkl4tzAICdKtoAQAdBIl7Y7hsPlx5w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-musl@0.48.0':
+    resolution: {integrity: sha512-g2SKTTurP5mWjd8Ecait0erYqmltL4IqW1EwttM25BxM6NiTt4ubobJYMR1uox1V2QgG4UfHH10CGRvWlUixjw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-openharmony-arm64@0.48.0':
+    resolution: {integrity: sha512-CIg24VgheEpvolHL2gQuax5qcQ602bRMHrJ9g8XsQr3iVj9aSPgopigBKuMqrXsupwkrU+RQCn5cG8PgFntR6w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxfmt/binding-win32-arm64-msvc@0.48.0':
+    resolution: {integrity: sha512-zeaWkcxcEULwkGF3I/HgEvcDPN8buYDrxibBUa/IFh5Vmwyge+KpLO+hEwSovW349H0O/C0Z2kaFmEzEDm00/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxfmt/binding-win32-ia32-msvc@0.48.0':
+    resolution: {integrity: sha512-yiEKnIAGvx5CyZQOlMaNlZkAbwT7/Quk0j3WLt+PR5hK+qYjPTRRJYDfD77wCBPLvEYAG41v4KG3iL0H+uxoxg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxfmt/binding-win32-x64-msvc@0.48.0':
+    resolution: {integrity: sha512-GSD2+7t2UoVMV2NgxXypa4bKewflPMAjYnF0Xw9/ht82ZfafAHhb8STwrEd7wlH2PFogt5zw3WVCxYJaHUdbeQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
 
   '@rollup/plugin-commonjs@28.0.9':
     resolution: {integrity: sha512-PIR4/OHZ79romx0BVVll/PkwWpJ7e5lsqFa3gFfcrFPWwLXLV39JVUzQV9RKjWerE7B845Hqjj9VYlQeieZ2dA==}
@@ -1401,6 +1523,11 @@ packages:
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
 
+  oxfmt@0.48.0:
+    resolution: {integrity: sha512-AVaLh+7XeGx+R1zfFV+f6VV61nT2MWVJXVUDhbTm5LBWGyNt64xAyh3NYYyjeY2WykNt9AvqSQLPHcbWquYF9g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
     engines: {node: '>=8'}
@@ -1680,6 +1807,10 @@ packages:
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinypool@2.1.0:
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
@@ -2335,6 +2466,63 @@ snapshots:
   '@octokit/types@16.0.0':
     dependencies:
       '@octokit/openapi-types': 27.0.0
+
+  '@oxfmt/binding-android-arm-eabi@0.48.0':
+    optional: true
+
+  '@oxfmt/binding-android-arm64@0.48.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-arm64@0.48.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-x64@0.48.0':
+    optional: true
+
+  '@oxfmt/binding-freebsd-x64@0.48.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.48.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.48.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-gnu@0.48.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-musl@0.48.0':
+    optional: true
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.48.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.48.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-musl@0.48.0':
+    optional: true
+
+  '@oxfmt/binding-linux-s390x-gnu@0.48.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-gnu@0.48.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-musl@0.48.0':
+    optional: true
+
+  '@oxfmt/binding-openharmony-arm64@0.48.0':
+    optional: true
+
+  '@oxfmt/binding-win32-arm64-msvc@0.48.0':
+    optional: true
+
+  '@oxfmt/binding-win32-ia32-msvc@0.48.0':
+    optional: true
+
+  '@oxfmt/binding-win32-x64-msvc@0.48.0':
+    optional: true
 
   '@rollup/plugin-commonjs@28.0.9(rollup@4.60.2)':
     dependencies:
@@ -3074,6 +3262,30 @@ snapshots:
 
   outdent@0.5.0: {}
 
+  oxfmt@0.48.0:
+    dependencies:
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.48.0
+      '@oxfmt/binding-android-arm64': 0.48.0
+      '@oxfmt/binding-darwin-arm64': 0.48.0
+      '@oxfmt/binding-darwin-x64': 0.48.0
+      '@oxfmt/binding-freebsd-x64': 0.48.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.48.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.48.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.48.0
+      '@oxfmt/binding-linux-arm64-musl': 0.48.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.48.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.48.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.48.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.48.0
+      '@oxfmt/binding-linux-x64-gnu': 0.48.0
+      '@oxfmt/binding-linux-x64-musl': 0.48.0
+      '@oxfmt/binding-openharmony-arm64': 0.48.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.48.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.48.0
+      '@oxfmt/binding-win32-x64-msvc': 0.48.0
+
   p-filter@2.1.0:
     dependencies:
       p-map: 2.1.0
@@ -3374,6 +3586,8 @@ snapshots:
       picomatch: 4.0.4
 
   tinypool@1.1.1: {}
+
+  tinypool@2.1.0: {}
 
   tinyrainbow@2.0.0: {}
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,10 +1,10 @@
-import { defineConfig } from "rollup";
 import commonjs from "@rollup/plugin-commonjs";
+import json from "@rollup/plugin-json";
 import nodeResolve from "@rollup/plugin-node-resolve";
 import terser from "@rollup/plugin-terser";
-import json from "@rollup/plugin-json";
-import { transform } from "esbuild";
 import builtinModulesList from "builtin-modules";
+import { transform } from "esbuild";
+import { defineConfig } from "rollup";
 
 const builtinModules = new Set(builtinModulesList);
 

--- a/scripts/bump.ts
+++ b/scripts/bump.ts
@@ -13,6 +13,6 @@ const readmePath = path.join(import.meta.dirname, "..", "README.md");
 const content = fs.readFileSync(readmePath, "utf8");
 const updatedContent = content.replace(
   /changesets\/action@[^\s]+/g,
-  `changesets/action@${releaseLine}`
+  `changesets/action@${releaseLine}`,
 );
 fs.writeFileSync(readmePath, updatedContent);

--- a/scripts/bump.ts
+++ b/scripts/bump.ts
@@ -1,6 +1,6 @@
-import { exec } from "@actions/exec";
 import fs from "node:fs";
 import path from "node:path";
+import { exec } from "@actions/exec";
 import pkgJson from "../package.json" with { type: "json" };
 
 process.chdir(path.join(import.meta.dirname, ".."));

--- a/scripts/release-pr.ts
+++ b/scripts/release-pr.ts
@@ -1,6 +1,5 @@
-import { exec } from "@actions/exec";
 import path from "node:path";
-
+import { exec } from "@actions/exec";
 import pkgJson from "../package.json" with { type: "json" };
 
 const tag = `v${pkgJson.version}`;

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,6 +1,5 @@
-import { exec, getExecOutput } from "@actions/exec";
 import path from "node:path";
-
+import { exec, getExecOutput } from "@actions/exec";
 import pkgJson from "../package.json" with { type: "json" };
 
 const tag = `v${pkgJson.version}`;

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -13,11 +13,11 @@ process.chdir(path.join(import.meta.dirname, ".."));
     ["ls-remote", "--exit-code", "origin", "--tags", `refs/tags/${tag}`],
     {
       ignoreReturnCode: true,
-    }
+    },
   );
   if (exitCode === 0) {
     console.log(
-      `Action is not being published because version ${tag} is already published`
+      `Action is not being published because version ${tag} is already published`,
     );
     return;
   }

--- a/src/git.ts
+++ b/src/git.ts
@@ -14,7 +14,7 @@ const push = async (branch: string, options: GitOptions) => {
 
 const switchToMaybeExistingBranch = async (
   branch: string,
-  options: GitOptions
+  options: GitOptions,
 ) => {
   let { stderr } = await getExecOutput("git", ["checkout", branch], {
     ignoreReturnCode: true,
@@ -41,7 +41,7 @@ const checkIfClean = async (options: GitOptions): Promise<boolean> => {
   const { stdout } = await getExecOutput(
     "git",
     ["status", "--porcelain"],
-    options
+    options,
   );
   return !stdout.length;
 };
@@ -71,7 +71,7 @@ export class Git {
       ],
       {
         cwd: this.cwd,
-      }
+      },
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-import * as core from "@actions/core";
 import fs from "node:fs/promises";
 import path from "node:path";
+import * as core from "@actions/core";
 import { Git } from "./git.ts";
 import { setupOctokit } from "./octokit.ts";
 import readChangesetState from "./readChangesetState.ts";

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
   core.info("setting GitHub credentials");
   await fs.writeFile(
     `${process.env.HOME}/.netrc`,
-    `machine github.com\nlogin github-actions[bot]\npassword ${githubToken}`
+    `machine github.com\nlogin github-actions[bot]\npassword ${githubToken}`,
   );
 
   let { changesets } = await readChangesetState(cwd);
@@ -56,7 +56,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
   let publishScript = core.getInput("publish");
   let hasChangesets = changesets.length !== 0;
   const hasNonEmptyChangesets = changesets.some(
-    (changeset) => changeset.releases.length > 0
+    (changeset) => changeset.releases.length > 0,
   );
   let hasPublishScript = !!publishScript;
 
@@ -67,12 +67,12 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
   switch (true) {
     case !hasChangesets && !hasPublishScript:
       core.info(
-        "No changesets present or were removed by merging release PR. Not publishing because no publish script found."
+        "No changesets present or were removed by merging release PR. Not publishing because no publish script found.",
       );
       return;
     case !hasChangesets && hasPublishScript: {
       core.info(
-        "No changesets found. Attempting to publish any unpublished packages to npm"
+        "No changesets found. Attempting to publish any unpublished packages to npm",
       );
 
       if (process.env.NPM_TOKEN) {
@@ -87,24 +87,24 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
           });
           if (authLine) {
             core.info(
-              "Found existing auth token for the npm registry in the user .npmrc file"
+              "Found existing auth token for the npm registry in the user .npmrc file",
             );
           } else {
             core.info(
-              "Didn't find existing auth token for the npm registry in the user .npmrc file, creating one"
+              "Didn't find existing auth token for the npm registry in the user .npmrc file, creating one",
             );
             await fs.appendFile(
               userNpmrcPath,
-              `\n//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}\n`
+              `\n//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}\n`,
             );
           }
         } else {
           core.info(
-            "No user .npmrc file found, creating one with NPM_TOKEN used as auth token"
+            "No user .npmrc file found, creating one with NPM_TOKEN used as auth token",
           );
           await fs.writeFile(
             userNpmrcPath,
-            `//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}\n`
+            `//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}\n`,
           );
         }
       } else if (
@@ -112,11 +112,11 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
         process.env.ACTIONS_ID_TOKEN_REQUEST_URL
       ) {
         core.info(
-          "No NPM_TOKEN found, but OIDC is available - using npm trusted publishing"
+          "No NPM_TOKEN found, but OIDC is available - using npm trusted publishing",
         );
       } else {
         core.info(
-          "No NPM_TOKEN or OIDC available - assuming npm is already authenticated"
+          "No NPM_TOKEN or OIDC available - assuming npm is already authenticated",
         );
       }
 
@@ -133,7 +133,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
         core.setOutput("published", "true");
         core.setOutput(
           "publishedPackages",
-          JSON.stringify(result.publishedPackages)
+          JSON.stringify(result.publishedPackages),
         );
       }
       return;

--- a/src/octokit.ts
+++ b/src/octokit.ts
@@ -9,7 +9,7 @@ export const setupOctokit = (githubToken: string) => {
       throttle: {
         onRateLimit: (retryAfter, options: any, octokit, retryCount) => {
           core.warning(
-            `Request quota exhausted for request ${options.method} ${options.url}`
+            `Request quota exhausted for request ${options.method} ${options.url}`,
           );
 
           if (retryCount <= 2) {
@@ -21,10 +21,10 @@ export const setupOctokit = (githubToken: string) => {
           retryAfter,
           options: any,
           octokit,
-          retryCount
+          retryCount,
         ) => {
           core.warning(
-            `SecondaryRateLimit detected for request ${options.method} ${options.url}`
+            `SecondaryRateLimit detected for request ${options.method} ${options.url}`,
           );
 
           if (retryCount <= 2) {
@@ -34,7 +34,7 @@ export const setupOctokit = (githubToken: string) => {
         },
       },
     },
-    throttling
+    throttling,
   );
 };
 

--- a/src/readChangesetState.ts
+++ b/src/readChangesetState.ts
@@ -8,7 +8,7 @@ export type ChangesetState = {
 };
 
 export default async function readChangesetState(
-  cwd: string = process.cwd()
+  cwd: string = process.cwd(),
 ): Promise<ChangesetState> {
   let preState = await readPreState(cwd);
   let changesets = await readChangesets(cwd);

--- a/src/readChangesetState.ts
+++ b/src/readChangesetState.ts
@@ -1,6 +1,6 @@
-import type { PreState, NewChangeset } from "@changesets/types";
 import { readPreState } from "@changesets/pre";
 import readChangesets from "@changesets/read";
+import type { PreState, NewChangeset } from "@changesets/types";
 
 export type ChangesetState = {
   preState: PreState | undefined;

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -1,8 +1,8 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import type { Changeset } from "@changesets/types";
 import writeChangeset from "@changesets/write";
 import fixturez from "fixturez";
-import fs from "node:fs/promises";
-import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Git } from "./git.ts";
 import { setupOctokit } from "./octokit.ts";

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -41,7 +41,7 @@ let f = fixturez(import.meta.dirname);
 const linkNodeModules = async (cwd: string) => {
   await fs.symlink(
     path.join(import.meta.dirname, "..", "node_modules"),
-    path.join(cwd, "node_modules")
+    path.join(cwd, "node_modules"),
   );
 };
 const writeChangesets = (changesets: Changeset[], cwd: string) => {
@@ -79,7 +79,7 @@ describe("version", () => {
           summary: "Awesome feature",
         },
       ],
-      cwd
+      cwd,
     );
 
     await runVersion({
@@ -114,7 +114,7 @@ describe("version", () => {
           summary: "Awesome feature",
         },
       ],
-      cwd
+      cwd,
     );
 
     await runVersion({
@@ -150,7 +150,7 @@ describe("version", () => {
           summary: "Awesome feature",
         },
       ],
-      cwd
+      cwd,
     );
 
     await runVersion({
@@ -185,7 +185,7 @@ describe("version", () => {
           summary: "Awesome feature",
         },
       ],
-      cwd
+      cwd,
     );
 
     await runVersion({
@@ -240,7 +240,7 @@ fluminis divesque vulnere aquis parce lapsis rabie si visa fulmineis.
 `,
         },
       ],
-      cwd
+      cwd,
     );
 
     await runVersion({
@@ -253,7 +253,7 @@ fluminis divesque vulnere aquis parce lapsis rabie si visa fulmineis.
 
     expect(mockedGithubMethods.pulls.create.mock.calls[0]).toMatchSnapshot();
     expect(mockedGithubMethods.pulls.create.mock.calls[0][0].body).toMatch(
-      /The changelog information of each package has been omitted from this message/
+      /The changelog information of each package has been omitted from this message/,
     );
   });
 
@@ -299,7 +299,7 @@ fluminis divesque vulnere aquis parce lapsis rabie si visa fulmineis.
 `,
         },
       ],
-      cwd
+      cwd,
     );
 
     await runVersion({
@@ -312,7 +312,7 @@ fluminis divesque vulnere aquis parce lapsis rabie si visa fulmineis.
 
     expect(mockedGithubMethods.pulls.create.mock.calls[0]).toMatchSnapshot();
     expect(mockedGithubMethods.pulls.create.mock.calls[0][0].body).toMatch(
-      /All release information have been omitted from this message, as the content exceeds the size limit/
+      /All release information have been omitted from this message, as the content exceeds the size limit/,
     );
   });
 
@@ -336,7 +336,7 @@ fluminis divesque vulnere aquis parce lapsis rabie si visa fulmineis.
           summary: "Awesome feature",
         },
       ],
-      cwd
+      cwd,
     );
 
     await runVersion({
@@ -370,7 +370,7 @@ fluminis divesque vulnere aquis parce lapsis rabie si visa fulmineis.
           summary: "Awesome feature",
         },
       ],
-      cwd
+      cwd,
     );
 
     await runVersion({

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,11 +1,11 @@
+import fs from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
 import * as core from "@actions/core";
 import { exec, getExecOutput } from "@actions/exec";
 import * as github from "@actions/github";
 import type { PreState } from "@changesets/types";
 import { type Package, getPackages } from "@manypkg/get-packages";
-import fs from "node:fs/promises";
-import { createRequire } from "node:module";
-import path from "node:path";
 import semverLt from "semver/functions/lt.js";
 import { Git } from "./git.ts";
 import type { Octokit } from "./octokit.ts";

--- a/src/run.ts
+++ b/src/run.ts
@@ -166,9 +166,11 @@ export async function runPublish({
 
 const requireChangesetsCliPkgJson = (cwd: string) => {
   try {
-    return require(require.resolve("@changesets/cli/package.json", {
-      paths: [cwd],
-    }));
+    return require(
+      require.resolve("@changesets/cli/package.json", {
+        paths: [cwd],
+      })
+    );
   } catch (err) {
     if (isErrorWithCode(err, "MODULE_NOT_FOUND")) {
       throw new Error(

--- a/src/run.ts
+++ b/src/run.ts
@@ -28,7 +28,7 @@ const MAX_CHARACTERS_PER_MESSAGE = 60000;
 
 const createRelease = async (
   octokit: Octokit,
-  { pkg, tagName }: { pkg: Package; tagName: string }
+  { pkg, tagName }: { pkg: Package; tagName: string },
 ) => {
   let changelog;
   try {
@@ -45,7 +45,7 @@ const createRelease = async (
     // we can find a changelog but not the entry for this version
     // if this is true, something has probably gone wrong
     throw new Error(
-      `Could not find changelog entry for ${pkg.packageJson.name}@${pkg.packageJson.version}`
+      `Could not find changelog entry for ${pkg.packageJson.name}@${pkg.packageJson.version}`,
     );
   }
 
@@ -91,7 +91,7 @@ export async function runPublish({
   let changesetPublishOutput = await getExecOutput(
     publishCommand,
     publishArgs,
-    { cwd, env: { ...process.env, GITHUB_TOKEN: githubToken } }
+    { cwd, env: { ...process.env, GITHUB_TOKEN: githubToken } },
   );
 
   let { packages, tool } = await getPackages(cwd);
@@ -111,7 +111,7 @@ export async function runPublish({
       if (pkg === undefined) {
         throw new Error(
           `Package "${pkgName}" not found.` +
-            "This is probably a bug in the action, please open an issue"
+            "This is probably a bug in the action, please open an issue",
         );
       }
       releasedPackages.push(pkg);
@@ -123,14 +123,14 @@ export async function runPublish({
           const tagName = `${pkg.packageJson.name}@${pkg.packageJson.version}`;
           await git.pushTag(tagName);
           await createRelease(octokit, { pkg, tagName });
-        })
+        }),
       );
     }
   } else {
     if (packages.length === 0) {
       throw new Error(
         `No package found.` +
-          "This is probably a bug in the action, please open an issue"
+          "This is probably a bug in the action, please open an issue",
       );
     }
     let pkg = packages[0];
@@ -169,13 +169,13 @@ const requireChangesetsCliPkgJson = (cwd: string) => {
     return require(
       require.resolve("@changesets/cli/package.json", {
         paths: [cwd],
-      })
+      }),
     );
   } catch (err) {
     if (isErrorWithCode(err, "MODULE_NOT_FOUND")) {
       throw new Error(
         `Have you forgotten to install \`@changesets/cli\` in "${cwd}"?`,
-        { cause: err }
+        { cause: err },
       );
     }
     throw err;
@@ -311,7 +311,7 @@ export async function runVersion({
       {
         cwd,
         env,
-      }
+      },
     );
   }
 
@@ -320,7 +320,7 @@ export async function runVersion({
     changedPackages.map(async (pkg) => {
       let changelogContents = await fs.readFile(
         path.join(pkg.dir, "CHANGELOG.md"),
-        "utf8"
+        "utf8",
       );
 
       let entry = getChangelogEntry(changelogContents, pkg.packageJson.version);
@@ -330,7 +330,7 @@ export async function runVersion({
         content: entry.content,
         header: `## ${pkg.packageJson.name}@${pkg.packageJson.version}`,
       };
-    })
+    }),
   );
 
   const finalPrTitle = `${prTitle}${!!preState ? ` (${preState.tag})` : ""}`;
@@ -355,8 +355,8 @@ export async function runVersion({
     `Existing pull requests: ${JSON.stringify(
       existingPullRequests.data,
       null,
-      2
-    )}`
+      2,
+    )}`,
   );
 
   await git.pushChanges({ branch: versionBranch, message: finalCommitMessage });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,11 @@
-import unified from "unified";
-import remarkParse from "remark-parse";
-import remarkStringify from "remark-stringify";
 import fs from "node:fs/promises";
+import { getPackages, type Package } from "@manypkg/get-packages";
 import type { Root } from "mdast";
 // @ts-ignore
 import mdastToString from "mdast-util-to-string";
-import { getPackages, type Package } from "@manypkg/get-packages";
+import remarkParse from "remark-parse";
+import remarkStringify from "remark-stringify";
+import unified from "unified";
 
 export const BumpLevels = {
   dep: 0,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,7 +21,7 @@ export async function getVersionsByDirectory(cwd: string) {
 
 export async function getChangedPackages(
   cwd: string,
-  previousVersions: Map<string, string>
+  previousVersions: Map<string, string>,
 ) {
   let { packages } = await getPackages(cwd);
   let changedPackages = new Set<Package>();
@@ -87,7 +87,7 @@ export function getChangelogEntry(changelog: string, version: string) {
 
 export function sortTheThings(
   a: { private: boolean; highestLevel: number },
-  b: { private: boolean; highestLevel: number }
+  b: { private: boolean; highestLevel: number },
 ) {
   if (a.private === b.private) {
     return b.highestLevel - a.highestLevel;
@@ -110,6 +110,6 @@ export function isErrorWithCode(err: unknown, code: string) {
 export function fileExists(filePath: string) {
   return fs.access(filePath, fs.constants.F_OK).then(
     () => true,
-    () => false
+    () => false,
   );
 }

--- a/types/fixturez.d.ts
+++ b/types/fixturez.d.ts
@@ -7,7 +7,7 @@ type Opts = {
 declare module "fixturez" {
   export default function (
     cwd: string,
-    opts?: Opts
+    opts?: Opts,
   ): {
     find: (a: string) => string;
     temp: () => string;


### PR DESCRIPTION
Enables import sorting and `trailingComma: "always"` so matches the changesets repo setup.

NOTE: It also sorts the package.json