### PR TITLE
Fix version/publish arg parsing

### DIFF
--- a/.changeset/lazy-glasses-stop.md
+++ b/.changeset/lazy-glasses-stop.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": patch
+---
+
+Fix custom version and publish command argument parsing

--- a/src/run.ts
+++ b/src/run.ts
@@ -86,13 +86,10 @@ export async function runPublish({
   createGithubReleases,
   cwd,
 }: PublishOptions): Promise<PublishResult> {
-  let [publishCommand, ...publishArgs] = script.split(/\s+/);
-
-  let changesetPublishOutput = await getExecOutput(
-    publishCommand,
-    publishArgs,
-    { cwd, env: { ...process.env, GITHUB_TOKEN: githubToken } },
-  );
+  let changesetPublishOutput = await getExecOutput(script, undefined, {
+    cwd,
+    env: { ...process.env, GITHUB_TOKEN: githubToken },
+  });
 
   let { packages, tool } = await getPackages(cwd);
   let releasedPackages: Package[] = [];
@@ -293,8 +290,7 @@ export async function runVersion({
   const env = { ...process.env, GITHUB_TOKEN: githubToken };
 
   if (script) {
-    let [versionCommand, ...versionArgs] = script.split(/\s+/);
-    await exec(versionCommand, versionArgs, { cwd, env });
+    await exec(script, undefined, { cwd, env });
   } else {
     let changesetsCliPkgJson = requireChangesetsCliPkgJson(cwd);
     let cmd = semverLt(changesetsCliPkgJson.version, "2.0.0")


### PR DESCRIPTION
We don't have to manually split by whitespace because github already does that for us:

- https://github.com/actions/toolkit/blob/8066c8132268398c77366dae936dac12c03d39ee/packages/exec/src/exec.ts#L22
- https://github.com/actions/toolkit/blob/8066c8132268398c77366dae936dac12c03d39ee/packages/exec/src/toolrunner.ts#L554

I feel like I've seen this reported before but I can't find it anymore.