### PR TITLE
chore: add node_id to PublishOptions type

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -60,6 +60,7 @@ const createRelease = async (
 
 type PublishOptions = {
   script: string;
+  node_id: string;
   githubToken: string;
   octokit: Octokit;
   createGithubReleases: boolean;


### PR DESCRIPTION
If `node_id` is not added to `PublishOptions` it will cause a type error here:

https://github.com/changesets/action/blob/031358f743b5a6199bd7a39bdc8b469280983df9/src/run.ts#L427