### PR TITLE
update note regarding `pull_request_target`

### DIFF
--- a/pr-status/README.md
+++ b/pr-status/README.md
@@ -11,7 +11,7 @@ See the [action metadata](action.yml) for details on the inputs and outputs.
 >
 > **Do not run untrusted code** when using the `pull_request_target` event.
 >
-> The example below only ***checks out*** and ***reads*** code, and does not ***execute*** any code from the fork.
+> The example below only **_checks out_** and **_reads_** code, and does not **_execute_** any code from the fork.
 >
 > Read more about the `pull_request_target` event in the [GitHub documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target).
 

--- a/pr-status/README.md
+++ b/pr-status/README.md
@@ -2,7 +2,16 @@
 
 This action generates the changesets status in PRs, e.g. whether it has changeset files and which packages will be released if the PR is merged.
 
-It requires the repo to be checked out, and automatically fetches the PR head ref into a temporary detached worktree in order to infer the changed files and packages. It also requires the [`pull_request_target`](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target) event to be triggered in order to have permissions to comment on the PR and to work in PRs from forks.
+It requires the repo to be checked out, and automatically fetches the PR head ref into a temporary detached worktree in order to infer the changed files and packages.
+
+> [!CAUTION]
+> **This action uses `pull_request_target` by default to support PRs from forks.**
+> 
+> Generally, **do not execute any code except for GitHub Actions** when using the `pull_request_target` event.
+> 
+> The example below only _checks out_ and does not _run_ any code from the PR.
+> 
+> Read more about the `pull_request_target` event in the [GitHub documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target).
 
 You can also use the [`pull_request`](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request) event if you prefer to lock permissions down and not run for PRs from forks. Make sure to add an if check to prevent the action from failing in fork PRs:
 
@@ -15,9 +24,6 @@ jobs:
 
 See the [action metadata](action.yml) for details on the inputs and outputs.
 
-> [!WARNING]
-> **Do not run untrusted code** when using the `pull_request_target` event. The example below only checks out code and does not run any code from the PR. Read more about the `pull_request_target` event in the [GitHub documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target).
-
 ## Example setup
 
 ```yaml
@@ -26,6 +32,8 @@ name: Comment Changesets status in PRs
 
 on:
   pull_request_target:
+
+permissions: {} # require explicitly stating all permissions in each job
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}

--- a/pr-status/README.md
+++ b/pr-status/README.md
@@ -9,9 +9,9 @@ See the [action metadata](action.yml) for details on the inputs and outputs.
 > [!CAUTION]
 > **This action uses `pull_request_target` by default to support PRs from forks.**
 >
-> Generally, **do not execute any code except for GitHub Actions** when using the `pull_request_target` event.
+> **Do not run untrusted code** when using the `pull_request_target` event.
 >
-> The example below only _checks out_ and does not _run_ any code from the PR.
+> The example below only ***checks out*** and ***reads*** code, and does not ***execute*** any code from the fork.
 >
 > Read more about the `pull_request_target` event in the [GitHub documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target).
 

--- a/pr-status/README.md
+++ b/pr-status/README.md
@@ -4,13 +4,15 @@ This action generates the changesets status in PRs, e.g. whether it has changese
 
 It requires the repo to be checked out, and automatically fetches the PR head ref into a temporary detached worktree in order to infer the changed files and packages.
 
+See the [action metadata](action.yml) for details on the inputs and outputs.
+
 > [!CAUTION]
 > **This action uses `pull_request_target` by default to support PRs from forks.**
-> 
+>
 > Generally, **do not execute any code except for GitHub Actions** when using the `pull_request_target` event.
-> 
+>
 > The example below only _checks out_ and does not _run_ any code from the PR.
-> 
+>
 > Read more about the `pull_request_target` event in the [GitHub documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target).
 
 You can also use the [`pull_request`](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request) event if you prefer to lock permissions down and not run for PRs from forks. Make sure to add an if check to prevent the action from failing in fork PRs:
@@ -22,7 +24,7 @@ jobs:
     # ...
 ```
 
-See the [action metadata](action.yml) for details on the inputs and outputs.
+You can also use the [Changesets Bot](https://github.com/apps/changeset-bot) if you don't want an extra action in your repo, or are worried about the `pull_request_target` event.
 
 ## Example setup
 


### PR DESCRIPTION
- changes the note about `pull_request_target` to a CAUTION instead of a WARNING
- merges the two sections about it into one
- adds a note about using the bot as an alternative