### PR TITLE
Remove cwd option

### DIFF
--- a/.changeset/lemon-turtles-itch.md
+++ b/.changeset/lemon-turtles-itch.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": major
+---
+
+Remove `cwd` option for `changesets/action`. Use the step `working-directory` option instead to change the directory.

--- a/action.yml
+++ b/action.yml
@@ -14,9 +14,6 @@ inputs:
   version:
     description: "The command to update version, edit CHANGELOG, read and delete changesets. Default to `changeset version` if not provided"
     required: false
-  cwd:
-    description: Sets the cwd for the node process. Default to `process.cwd()`
-    required: false
   commit:
     description: |
       The commit message. Default to `Version Packages`

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,8 +19,8 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
     return;
   }
 
-  const cwd = path.resolve(getOptionalInput("cwd") ?? "");
-  core.info(`using resolved cwd: ${cwd}`);
+  // If the user needs to change the cwd, set `working-directory` in the step instead
+  const cwd = process.cwd();
 
   const octokit = setupOctokit(githubToken);
   const commitMode = getOptionalInput("commitMode") ?? "git-cli";


### PR DESCRIPTION
This was needed before as changeset CLI couldn't run within a nested directory, but we had already supported that recently, even in changesets v2