### PR TITLE
Fixed usage of `--from-publish-plan` flag used by the `/pack` subaction

### DIFF
--- a/.changeset/ready-mangos-boil.md
+++ b/.changeset/ready-mangos-boil.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": patch
+---
+
+Fixed usage of `--from-publish-plan` flag used by the `/pack` subaction

--- a/src/pack/index.ts
+++ b/src/pack/index.ts
@@ -49,7 +49,7 @@ async function pack(
 ) {
   const cliArgs = ["pack", "--out-dir", args.outDir];
   if (args.publishPlanPath) {
-    cliArgs.push("--from-plan", args.publishPlanPath);
+    cliArgs.push("--from-publish-plan", args.publishPlanPath);
   }
 
   await execChangesetsCli(cliArgs, {


### PR DESCRIPTION
The artifact name was already good but I forgot that I had to also adjust this flag given https://github.com/changesets/changesets/pull/2108