### PR TITLE
Remove GITHUB_TOKEN env var support

### DIFF
--- a/.changeset/fiery-toes-vanish.md
+++ b/.changeset/fiery-toes-vanish.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": major
+---
+
+Remove support for passing custom GitHub token through the GITHUB_TOKEN environment variable. It should be passed to the `github-token` input instead.

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,16 +3,16 @@ import * as core from "@actions/core";
 import { GitHub } from "./github.ts";
 import readChangesetState from "./readChangesetState.ts";
 import { runPublish, runVersion } from "./run.ts";
-import { fileExists, getOptionalInput } from "./utils.ts";
+import { fileExists, getOptionalInput, getRequiredInput } from "./utils.ts";
 
 (async () => {
-  // to maintain compatibility with workflows created before github-token input was introduced
-  // it's important to prefer the explicitly set GITHUB_TOKEN over the default token coming from github.token
-  let githubToken = process.env.GITHUB_TOKEN || core.getInput("github-token");
-
-  if (!githubToken) {
-    core.setFailed("Please add the GITHUB_TOKEN to the changesets action");
-    return;
+  const githubToken = getRequiredInput("github-token");
+  if (process.env.GITHUB_TOKEN && process.env.GITHUB_TOKEN !== githubToken) {
+    throw new Error(
+      'The GITHUB_TOKEN environment variable is set and does not match the "github-token" input. ' +
+        'Please pass the custom GitHub token to the "github-token" input and ' +
+        "remove the GITHUB_TOKEN environment variable to avoid conflicts.",
+    );
   }
 
   // If the user needs to change the cwd, set `working-directory` in the step instead


### PR DESCRIPTION
This aligns with the behaviour with the other sub-actions, but with an error if the old pattern is still used.