### PR TITLE
Split git tag and github release options

### DIFF
--- a/.changeset/chubby-geese-sink.md
+++ b/.changeset/chubby-geese-sink.md
@@ -2,6 +2,6 @@
 "@changesets/action": major
 ---
 
-Add a new `create-git-tags` option that complements `create-github-releases` to control specifically if git tags should be created but not GitHub releases.
+Add a new `push-git-tags` option that complements `create-github-releases` to control specifically if git tags should be created but not GitHub releases.
 
-If `create-github-releases` was previously set to `false`, which also indirectly disabled git tag creation, git tags will now be created instead by default. If this is not desired, set `create-git-tags` to `false` explicitly.
+If `create-github-releases` was previously set to `false`, which also indirectly disabled git tag creation, git tags will now be created instead by default. If this is not desired, set `push-git-tags` to `false` explicitly.

--- a/.changeset/chubby-geese-sink.md
+++ b/.changeset/chubby-geese-sink.md
@@ -1,0 +1,7 @@
+---
+"@changesets/action": major
+---
+
+Add a new `create-git-tags` option that complements `create-github-releases` to control specifically if git tags should be created but not GitHub releases.
+
+If `create-github-releases` was previously set to `false`, which also indirectly disabled git tag creation, git tags will now be created instead by default. If this is not desired, set `create-git-tags` to `false` explicitly.

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,12 @@ inputs:
     description: "A boolean value to indicate whether to create Github releases after `publish` or not"
     required: false
     default: true
+  create-git-tags:
+    description: >
+      Whether to create git tags after publish. If `create-github-releases` is set to `true`,
+      this option will also always be `true`.
+    required: false
+    default: true
   commitMode:
     description: >
       An enum to specify the commit mode. Use "git-cli" to push changes using the Git CLI,

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
     description: "A boolean value to indicate whether to create Github releases after `publish` or not"
     required: false
     default: true
-  create-git-tags:
+  push-git-tags:
     description: >
       Whether to create git tags after publish. If `create-github-releases` is set to `true`,
       this option will also always be `true`.

--- a/publish/action.yml
+++ b/publish/action.yml
@@ -18,6 +18,12 @@ inputs:
     description: "Whether to create Github releases after publish"
     required: false
     default: true
+  create-git-tags:
+    description: >
+      Whether to create git tags after publish. If `create-github-releases` is set to `true`,
+      this option will also always be `true`.
+    required: false
+    default: true
 outputs:
   published:
     description: "A boolean value to indicate whether a publishing has happened or not"

--- a/publish/action.yml
+++ b/publish/action.yml
@@ -18,7 +18,7 @@ inputs:
     description: "Whether to create Github releases after publish"
     required: false
     default: true
-  create-git-tags:
+  push-git-tags:
     description: >
       Whether to create git tags after publish. If `create-github-releases` is set to `true`,
       this option will also always be `true`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,13 +111,13 @@ import { fileExists, getOptionalInput, getRequiredInput } from "./utils.ts";
       }
 
       const createGithubReleases = core.getBooleanInput("createGithubReleases");
-      const createGitTags =
-        createGithubReleases || core.getBooleanInput("create-git-tags");
+      const pushGitTags =
+        createGithubReleases || core.getBooleanInput("push-git-tags");
       const result = await runPublish({
         script: publishScript,
         github,
         createGithubReleases,
-        createGitTags,
+        pushGitTags,
         cwd,
       });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,10 +110,14 @@ import { fileExists, getOptionalInput } from "./utils.ts";
         );
       }
 
+      const createGithubReleases = core.getBooleanInput("createGithubReleases");
+      const createGitTags =
+        createGithubReleases || core.getBooleanInput("create-git-tags");
       const result = await runPublish({
         script: publishScript,
         github,
-        createGithubReleases: core.getBooleanInput("createGithubReleases"),
+        createGithubReleases,
+        createGitTags,
         cwd,
       });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,9 +122,17 @@ import {
         );
       }
 
-      const createGithubReleases = core.getBooleanInput("create-github-releases");
-      const pushGitTags =
-        createGithubReleases || core.getBooleanInput("push-git-tags");
+      const createGithubReleases = core.getBooleanInput(
+        "create-github-releases",
+      );
+      const pushGitTags = core.getBooleanInput("push-git-tags");
+      if (createGithubReleases && !pushGitTags) {
+        throw new Error(
+          "The input 'create-github-releases' is set to true, but 'push-git-tags' is set to false. " +
+            "Creating GitHub releases requires pushing git tags. Please set 'push-git-tags' to true " +
+            "or set 'create-github-releases' to false.",
+        );
+      }
       const result = await runPublish({
         script: publishScript,
         github,

--- a/src/publish/index.ts
+++ b/src/publish/index.ts
@@ -20,6 +20,8 @@ async function main() {
   const script = getOptionalInput("script");
   const packDirArtifactId = getOptionalInput("pack-dir-artifact-id");
   const createGithubReleases = core.getBooleanInput("create-github-releases");
+  const createGitTags =
+    createGithubReleases || core.getBooleanInput("create-git-tags");
 
   // If the user needs to change the cwd, set `working-directory` in the step instead
   const cwd = process.cwd();
@@ -39,6 +41,7 @@ async function main() {
     script,
     github,
     createGithubReleases,
+    createGitTags,
     cwd,
     fromPackDir,
   });

--- a/src/publish/index.ts
+++ b/src/publish/index.ts
@@ -20,8 +20,8 @@ async function main() {
   const script = getOptionalInput("script");
   const packDirArtifactId = getOptionalInput("pack-dir-artifact-id");
   const createGithubReleases = core.getBooleanInput("create-github-releases");
-  const createGitTags =
-    createGithubReleases || core.getBooleanInput("create-git-tags");
+  const pushGitTags =
+    createGithubReleases || core.getBooleanInput("push-git-tags");
 
   // If the user needs to change the cwd, set `working-directory` in the step instead
   const cwd = process.cwd();
@@ -41,7 +41,7 @@ async function main() {
     script,
     github,
     createGithubReleases,
-    createGitTags,
+    pushGitTags,
     cwd,
     fromPackDir,
   });

--- a/src/publish/index.ts
+++ b/src/publish/index.ts
@@ -20,8 +20,15 @@ async function main() {
   const script = getOptionalInput("script");
   const packDirArtifactId = getOptionalInput("pack-dir-artifact-id");
   const createGithubReleases = core.getBooleanInput("create-github-releases");
-  const pushGitTags =
-    createGithubReleases || core.getBooleanInput("push-git-tags");
+  const pushGitTags = core.getBooleanInput("push-git-tags");
+
+  if (createGithubReleases && !pushGitTags) {
+    throw new Error(
+      "The input 'create-github-releases' is set to true, but 'push-git-tags' is set to false. " +
+        "Creating GitHub releases requires pushing git tags. Please set 'push-git-tags' to true " +
+        "or set 'create-github-releases' to false.",
+    );
+  }
 
   // If the user needs to change the cwd, set `working-directory` in the step instead
   const cwd = process.cwd();

--- a/src/run.ts
+++ b/src/run.ts
@@ -65,7 +65,7 @@ type PublishOptions = {
   script?: string;
   fromPackDir?: string;
   createGithubReleases: boolean;
-  createGitTags: boolean;
+  pushGitTags: boolean;
   github: GitHub;
   cwd: string;
 };
@@ -88,7 +88,7 @@ export async function runPublish({
   fromPackDir,
   github,
   createGithubReleases,
-  createGitTags,
+  pushGitTags,
   cwd,
 }: PublishOptions): Promise<PublishResult> {
   const { octokit } = github;
@@ -139,11 +139,11 @@ export async function runPublish({
       releasedPackages.push(pkg);
     }
 
-    if (createGithubReleases || createGitTags) {
+    if (createGithubReleases || pushGitTags) {
       await Promise.all(
         releasedPackages.map(async (pkg) => {
           const tagName = `${pkg.packageJson.name}@${pkg.packageJson.version}`;
-          if (createGitTags) {
+          if (pushGitTags) {
             await github.pushTag(tagName);
           }
           if (createGithubReleases) {
@@ -168,7 +168,7 @@ export async function runPublish({
       if (match) {
         releasedPackages.push(pkg);
         const tagName = `v${pkg.packageJson.version}`;
-        if (createGitTags) {
+        if (pushGitTags) {
           await github.pushTag(tagName);
         }
         if (createGithubReleases) {

--- a/src/run.ts
+++ b/src/run.ts
@@ -65,6 +65,7 @@ type PublishOptions = {
   script?: string;
   fromPackDir?: string;
   createGithubReleases: boolean;
+  createGitTags: boolean;
   github: GitHub;
   cwd: string;
 };
@@ -87,6 +88,7 @@ export async function runPublish({
   fromPackDir,
   github,
   createGithubReleases,
+  createGitTags,
   cwd,
 }: PublishOptions): Promise<PublishResult> {
   const { octokit } = github;
@@ -137,12 +139,16 @@ export async function runPublish({
       releasedPackages.push(pkg);
     }
 
-    if (createGithubReleases) {
+    if (createGithubReleases || createGitTags) {
       await Promise.all(
         releasedPackages.map(async (pkg) => {
           const tagName = `${pkg.packageJson.name}@${pkg.packageJson.version}`;
-          await github.pushTag(tagName);
-          await createRelease(octokit, { pkg, tagName });
+          if (createGitTags) {
+            await github.pushTag(tagName);
+          }
+          if (createGithubReleases) {
+            await createRelease(octokit, { pkg, tagName });
+          }
         }),
       );
     }
@@ -161,9 +167,11 @@ export async function runPublish({
 
       if (match) {
         releasedPackages.push(pkg);
-        if (createGithubReleases) {
-          const tagName = `v${pkg.packageJson.version}`;
+        const tagName = `v${pkg.packageJson.version}`;
+        if (createGitTags) {
           await github.pushTag(tagName);
+        }
+        if (createGithubReleases) {
           await createRelease(octokit, { pkg, tagName });
         }
         break;


### PR DESCRIPTION
fix #247
fix #547 

NOTE: the above issues requested documentation improvements, but I have not done them here yet. I think probably it's easiest to consolidate all the docs update once we've finished reworking the actions & sub-actions.

### Possible alternatives

~~1. I wonder if it should be `push-git-tags` instead of `create-git-tags`, because we'd actually only do the pushing.~~ (renamed)
1. This is a breaking change because `create-github-releases: false` previously also disabled push tags, but now it'd push by default, unless set `push-git-tags: true` explicitly.
  
    We can kinda prevent this breaking change by making `push-git-tags` always follow the value of `create-github-releases`, unless `push-git-tags` was explicitly set, but I feel it's a bit hard to follow compared to the current behaviour, where both are independent options, just that `create-github-releases: true` will always force `push-git-tags: true` because inherently that's how github releases work.

    Or we support some sort of `create-github-releases: "tag-only"` but this also seems a bit weird.