### PR TITLE
Rename root action inputs and outputs

### DIFF
--- a/.changeset/eighty-parks-tickle.md
+++ b/.changeset/eighty-parks-tickle.md
@@ -1,0 +1,17 @@
+---
+"@changesets/action": major
+---
+
+Rename the root action inputs and outputs to better match the sub-actions' conventions.
+
+Inputs:
+
+- `version` -> `version-script`
+- `publish` -> `publish-script`
+- `commit` -> `commit-message`
+- `title` -> `pr-title`
+- `branch` -> `pr-base-branch`
+
+Outputs:
+
+- `pull-request-number` -> `pr-number`

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ jobs:
         uses: changesets/action@v2
         with:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
-          publish: pnpm release
+          publish-script: pnpm release
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -217,7 +217,7 @@ jobs:
         uses: changesets/action@v2
         with:
           # this expects you to have a npm script called version that runs some logic and then calls `changeset version`.
-          version: pnpm version
+          version-script: pnpm version
 ```
 
 #### With Yarn 2 / Plug'n'Play
@@ -227,6 +227,6 @@ If you are using [Yarn Plug'n'Play](https://yarnpkg.com/features/pnp), you shoul
 ```yaml
 - uses: changesets/action@v2
   with:
-    version: yarn changeset version
+    version-script: yarn changeset version
     # ...
 ```

--- a/action.yml
+++ b/action.yml
@@ -8,25 +8,28 @@ inputs:
     description: "The GitHub token to use for authentication. Defaults to the GitHub-provided token."
     required: false
     default: ${{ github.token }}
-  publish:
+  publish-script:
     description: "The command to use to build and publish packages"
     required: false
-  version:
+  version-script:
     description: "The command to update version, edit CHANGELOG, read and delete changesets. Default to `changeset version` if not provided"
     required: false
-  commit:
-    description: |
-      The commit message. Default to `Version Packages`
+  commit-message:
+    description: "The commit message. Default to `Version Packages`"
     required: false
-  title:
-    description: The pull request title. Default to `Version Packages`
+    default: "Version Packages"
+  pr-title:
+    description: "The pull request title. Default to `Version Packages`"
     required: false
-  setup-git-user:
-    description: Sets up the git user for commits as `"github-actions[bot]"`. Default to `true`
+    default: "Version Packages"
+  pr-draft:
+    description: "Controls draft PR behavior. Use 'create' to create new version PRs as draft, or 'always' to also convert existing version PRs back to draft when updating them."
     required: false
-    default: true
+  pr-base-branch:
+    description: "Sets the base branch of the PR. Defaults to `github.ref_name`."
+    required: false
   create-github-releases:
-    description: "A boolean value to indicate whether to create Github releases after `publish` or not"
+    description: "Whether to create Github releases after publish"
     required: false
     default: true
   commit-mode:
@@ -37,12 +40,10 @@ inputs:
       or app who owns the GITHUB_TOKEN.
     required: false
     default: "git-cli"
-  branch:
-    description: Sets the branch in which the action will run. Default to `github.ref_name` if not provided
+  setup-git-user:
+    description: Sets up the git user for commits as `"github-actions[bot]"`. Default to `true`
     required: false
-  pr-draft:
-    description: 'Controls draft PR behavior. Use "create" to create new version PRs as draft, or "always" to also convert existing version PRs back to draft when updating them.'
-    required: false
+    default: true
 outputs:
   published:
     description: A boolean value to indicate whether a publishing is happened or not
@@ -51,7 +52,7 @@ outputs:
       A JSON array to present the published packages. The format is `[{"name": "@xx/xx", "version": "1.2.0"}, {"name": "@xx/xy", "version": "0.8.9"}]`
   has-changesets:
     description: A boolean about whether there were changesets. Useful if you want to create your own publishing functionality.
-  pull-request-number:
+  pr-number:
     description: The pull request number that was created or updated
 branding:
   icon: "package"

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,9 +12,14 @@ import {
 
 (async () => {
   throwOnRenamedInputs({
-    commitMode: "commit-mode",
-    createGithubReleases: "create-github-releases",
+    publish: "publish-script",
+    version: "version-script",
+    commit: "commit-mesage",
+    title: "pr-title",
+    branch: "pr-base-branch",
     prDraft: "pr-draft",
+    createGithubReleases: "create-github-releases",
+    commitMode: "commit-mode",
     setupGitUser: "setup-git-user",
   });
 
@@ -55,7 +60,7 @@ import {
 
   let { changesets } = await readChangesetState(cwd);
 
-  let publishScript = core.getInput("publish");
+  let publishScript = core.getInput("publish-script");
   let hasChangesets = changesets.length !== 0;
   const hasNonEmptyChangesets = changesets.some(
     (changeset) => changeset.releases.length > 0,
@@ -156,17 +161,17 @@ import {
       return;
     case hasChangesets: {
       const { pullRequestNumber } = await runVersion({
-        script: getOptionalInput("version"),
+        script: getOptionalInput("version-script"),
         github,
         cwd,
-        prTitle: getOptionalInput("title"),
-        commitMessage: getOptionalInput("commit"),
+        prTitle: getOptionalInput("pr-title"),
+        commitMessage: getOptionalInput("commit-message"),
         hasPublishScript,
         prDraft,
-        branch: getOptionalInput("branch"),
+        branch: getOptionalInput("pr-base-branch"),
       });
 
-      core.setOutput("pull-request-number", String(pullRequestNumber));
+      core.setOutput("pr-number", String(pullRequestNumber));
 
       return;
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -136,12 +136,21 @@ export function getRequiredInput(name: string) {
 }
 
 export function throwOnRenamedInputs(renames: Record<string, string>) {
+  const references: Record<string, string> = {};
+
   for (const [oldInput, newInput] of Object.entries(renames)) {
     if (core.getInput(oldInput)) {
-      throw new Error(
-        `The input "${oldInput}" has been renamed to "${newInput}". Please update your workflow file.`,
-      );
+      references[oldInput] = newInput;
     }
+  }
+
+  if (Object.keys(references).length > 0) {
+    const list = Object.entries(references)
+      .map(([oldInput, newInput]) => `- "${oldInput}" -> "${newInput}"`)
+      .join("\n");
+    throw new Error(
+      `The following inputs have been renamed:\n${list}\nPlease update your workflow file.`,
+    );
   }
 }
 

--- a/version/action.yml
+++ b/version/action.yml
@@ -37,7 +37,9 @@ inputs:
     description: Sets up the git user for commits as `"github-actions[bot]"`. Default to `true`
     required: false
     default: true
-outputs: {}
+outputs:
+  pr-number:
+    description: The pull request number that was created or updated
 branding:
   icon: package
   color: blue


### PR DESCRIPTION
Follow-up on #668. I also copied the input descriptions from the sub-actions as they're more up-to-date and concise. And also copied the order of them.

Inputs:

- `version` -> `version-script`
- `publish` -> `publish-script`
- `commit` -> `commit-message`
- `title` -> `pr-title`
- `branch` -> `pr-base-branch`

Outputs:

- `pull-request-number` -> `pr-number`

---

These changes are kinda huge the more I see it. Should we consider making them work but log a warning instead?