### PR TITLE
Don't push tags in our custom release script

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,11 +1,15 @@
 import { Buffer } from "node:buffer";
 import path from "node:path";
 import { exec } from "@actions/exec";
+import major from "semver/functions/major.js";
+import prerelease from "semver/functions/prerelease.js";
 import pkgJson from "../package.json" with { type: "json" };
 
 const tag = `v${pkgJson.version}`;
-const releaseLine = `v${pkgJson.version.split(".")[0]}`;
-const isPrerelease = pkgJson.version.includes("-");
+const prereleaseTag = prerelease(pkgJson.version)?.[0];
+const releaseLine = `v${major(pkgJson.version)}${
+  prereleaseTag === undefined ? "" : `-${prereleaseTag}`
+}`;
 const githubToken = process.env.GITHUB_TOKEN;
 if (!githubToken) {
   throw new Error("GITHUB_TOKEN is required");
@@ -26,16 +30,10 @@ await exec("git", ["commit", "-m", tag]);
 
 await exec("changeset", ["git-tag"]);
 
-if (isPrerelease) {
-  await exec("git", ["push", "origin", `refs/tags/${tag}`], {
+await exec(
+  "git",
+  ["push", "--force", "origin", `HEAD:refs/heads/${releaseLine}`],
+  {
     env: gitEnv,
-  });
-} else {
-  await exec(
-    "git",
-    ["push", "--force", "origin", `HEAD:refs/heads/${releaseLine}`],
-    {
-      env: gitEnv,
-    },
-  );
-}
+  },
+);

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,6 +1,6 @@
 import { Buffer } from "node:buffer";
 import path from "node:path";
-import { exec } from "@actions/exec";
+import { exec, getExecOutput } from "@actions/exec";
 import major from "semver/functions/major.js";
 import prerelease from "semver/functions/prerelease.js";
 import pkgJson from "../package.json" with { type: "json" };
@@ -25,8 +25,22 @@ const gitEnv = {
 process.chdir(path.join(import.meta.dirname, ".."));
 
 await exec("git", ["checkout", "--detach"]);
+// Stable timestamps make retries produce the same commit when dist is unchanged.
+const { stdout } = await getExecOutput("git", [
+  "show",
+  "--no-patch",
+  "--format=%cI",
+  "HEAD",
+]);
+const commitDate = stdout.trim();
 await exec("git", ["add", "--force", "dist"]);
-await exec("git", ["commit", "-m", tag]);
+await exec("git", ["commit", "-m", tag], {
+  env: {
+    ...process.env,
+    GIT_AUTHOR_DATE: commitDate,
+    GIT_COMMITTER_DATE: commitDate,
+  },
+});
 
 await exec("changeset", ["git-tag"]);
 
@@ -35,6 +49,7 @@ await exec(
   [
     "push",
     "--force",
+    // The action pushes tags through the API; override any push.followTags config.
     "--no-follow-tags",
     "origin",
     `HEAD:refs/heads/${releaseLine}`,

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -33,13 +33,7 @@ if (isPrerelease) {
 } else {
   await exec(
     "git",
-    [
-      "push",
-      "--force",
-      "--follow-tags",
-      "origin",
-      `HEAD:refs/heads/${releaseLine}`,
-    ],
+    ["push", "--force", "origin", `HEAD:refs/heads/${releaseLine}`],
     {
       env: gitEnv,
     },

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -32,7 +32,13 @@ await exec("changeset", ["git-tag"]);
 
 await exec(
   "git",
-  ["push", "--force", "origin", `HEAD:refs/heads/${releaseLine}`],
+  [
+    "push",
+    "--force",
+    "--no-follow-tags",
+    "origin",
+    `HEAD:refs/heads/${releaseLine}`,
+  ],
   {
     env: gitEnv,
   },

--- a/src/github.ts
+++ b/src/github.ts
@@ -225,14 +225,14 @@ export class GitHub {
     );
   }
 
-  async pushTag(tag: string) {
+  async pushTag(tag: string, commit = context.sha) {
     if (!this.pushWithGitCli) {
       try {
         const { data: tagObject } = await this.octokit.rest.git.createTag({
           ...context.repo,
           tag,
           message: tag,
-          object: context.sha,
+          object: commit,
           type: "commit",
         });
         await this.octokit.rest.git.createRef({

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert/strict";
 import { Buffer } from "node:buffer";
 import * as core from "@actions/core";
 import { exec, getExecOutput } from "@actions/exec";
@@ -225,6 +226,27 @@ export class GitHub {
     );
   }
 
+  async #getRemoteTagCommit(tag: string) {
+    const { data: ref } = await this.octokit.rest.git.getRef({
+      ...context.repo,
+      ref: `tags/${tag}`,
+    });
+    let target: { type: string; sha: string } = ref.object;
+    while (target.type === "tag") {
+      const { data: tagObject } = await this.octokit.rest.git.getTag({
+        ...context.repo,
+        tag_sha: target.sha,
+      });
+      target = tagObject.object;
+    }
+    assert.equal(
+      target.type,
+      "commit",
+      `Tag ${tag} points to a ${target.type}, not a commit`,
+    );
+    return target.sha;
+  }
+
   async pushTag(tag: string, commit = context.sha) {
     if (!this.pushWithGitCli) {
       try {
@@ -242,6 +264,12 @@ export class GitHub {
         });
       } catch (err) {
         if (isAlreadyExistingRefError(err)) {
+          const remoteCommit = await this.#getRemoteTagCommit(tag);
+          assert.equal(
+            remoteCommit,
+            commit,
+            `Tag ${tag} points to commit ${remoteCommit}, expected ${commit}`,
+          );
           // The tag was likely pushed by a custom publish script.
           core.info(`Tag ${tag} already exists`);
           return;

--- a/src/github.ts
+++ b/src/github.ts
@@ -67,6 +67,19 @@ function getHttpUrl(remoteUrl: string): string | undefined {
   }
 }
 
+function isAlreadyExistingRefError(error: unknown) {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    "message" in error &&
+    typeof error.status === "number" &&
+    typeof error.message === "string" &&
+    error.status === 422 &&
+    error.message.includes("Reference already exists")
+  );
+}
+
 export class GitHub {
   readonly #githubToken: string;
   readonly octokit: Octokit;
@@ -214,16 +227,28 @@ export class GitHub {
 
   async pushTag(tag: string) {
     if (!this.pushWithGitCli) {
-      return this.octokit.rest.git
-        .createRef({
+      try {
+        const { data: tagObject } = await this.octokit.rest.git.createTag({
+          ...context.repo,
+          tag,
+          message: tag,
+          object: context.sha,
+          type: "commit",
+        });
+        await this.octokit.rest.git.createRef({
           ...context.repo,
           ref: `refs/tags/${tag}`,
-          sha: context.sha,
-        })
-        .catch((err) => {
-          // Assuming tag was manually pushed in custom publish script
-          core.warning(`Failed to create tag ${tag}: ${err.message}`);
+          sha: tagObject.sha,
         });
+      } catch (err) {
+        if (isAlreadyExistingRefError(err)) {
+          // The tag was likely pushed by a custom publish script.
+          core.info(`Tag ${tag} already exists`);
+          return;
+        }
+        throw err;
+      }
+      return;
     }
     await exec("git", ["push", "origin", tag], {
       cwd: this.cwd,

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,3 +1,5 @@
+import assert from "node:assert/strict";
+import { Buffer } from "node:buffer";
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -155,6 +157,45 @@ async function readChangesetsOutput(outputPath: string) {
   return events;
 }
 
+type Release = {
+  pkg: Package;
+  tag: string;
+  commit?: string;
+};
+
+async function getTagCommits(cwd: string, tags: string[]) {
+  if (tags.length === 0) {
+    return [];
+  }
+  const refs = tags.map((tag) => `refs/tags/${tag}^{commit}`);
+  const { stdout } = await getExecOutput(
+    "git",
+    ["cat-file", "--batch-check=%(objectname) %(objecttype)"],
+    {
+      cwd,
+      input: Buffer.from(`${refs.join("\n")}\n`),
+    },
+  );
+  const lines = stdout.trim().split(/\r?\n/);
+  assert.equal(
+    lines.length,
+    tags.length,
+    "Git returned an unexpected number of tag targets",
+  );
+  return lines.map((line, index) => {
+    if (line === `${refs[index]} missing`) {
+      return undefined;
+    }
+    const [commit, type] = line.split(" ");
+    assert.equal(
+      type,
+      "commit",
+      `Tag ${tags[index]} does not point to a commit`,
+    );
+    return commit;
+  });
+}
+
 export async function runPublish({
   script,
   fromPackDir,
@@ -214,7 +255,7 @@ export async function runPublish({
     );
     output = [];
   }
-  let releases = output.map((event) => {
+  let releases: Release[] = output.map((event) => {
     let pkg = packagesByName.get(event.packageName);
     if (pkg === undefined) {
       throw new Error(
@@ -232,11 +273,22 @@ export async function runPublish({
     );
   }
 
+  if (pushGitTags) {
+    const commits = await getTagCommits(
+      cwd,
+      releases.map(({ tag }) => tag),
+    );
+    releases = releases.map((release, index) => ({
+      ...release,
+      commit: commits[index],
+    }));
+  }
+
   if (createGithubReleases || pushGitTags) {
     await Promise.all(
-      releases.map(async ({ pkg, tag }) => {
+      releases.map(async ({ pkg, tag, commit }) => {
         if (pushGitTags) {
-          await github.pushTag(tag);
+          await github.pushTag(tag, commit);
         }
         if (createGithubReleases) {
           await createRelease(octokit, { pkg, tagName: tag });

--- a/src/run.ts
+++ b/src/run.ts
@@ -167,7 +167,7 @@ async function getTagCommits(cwd: string, tags: string[]) {
   if (tags.length === 0) {
     return [];
   }
-  const refs = tags.map((tag) => `refs/tags/${tag}^{commit}`);
+  const refs = tags.map((tag) => `refs/tags/${tag}^{}`);
   const { stdout } = await getExecOutput(
     "git",
     ["cat-file", "--batch-check=%(objectname) %(objecttype)"],


### PR DESCRIPTION
In https://github.com/changesets/action/actions/runs/30812557230/job/91682567379, I noticed this:
```
/home/runner/work/action/action/node_modules/.bin/changeset git-tag
🦋 changeset v3.0.0-next.8
25l◇  Created tags:
   - v2.0.0-next.4
25h[command]/usr/bin/git push origin refs/tags/v2.0.0-next.4
remote: Bypassed rule violations for refs/tags/v2.0.0-next.4:        
remote: 
remote: - Cannot create ref due to creations being restricted.        
remote: 
To https://github.com/changesets/action
 * [new tag]         v2.0.0-next.4 -> v2.0.0-next.4
Warning: Failed to create tag v2.0.0-next.4: Reference already exists - https://docs.github.com/rest/git/refs#create-a-reference
```

In this draft PR, I'm just exploring various tag-related improvements. I don't want to land this PR now - gotta rethink all the implications.