### PR TITLE
Fix typo in renamed inputs

### DIFF
--- a/.changeset/metal-aliens-check.md
+++ b/.changeset/metal-aliens-check.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": patch
+---
+
+Fixed typoo in renamed parameters from v1 to v2

--- a/.changeset/metal-aliens-check.md
+++ b/.changeset/metal-aliens-check.md
@@ -2,4 +2,4 @@
 "@changesets/action": patch
 ---
 
-Fixed typoo in renamed parameters from v1 to v2
+Fixed typo in renamed inputs from v1 to v2

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import {
   throwOnRenamedInputs({
     publish: "publish-script",
     version: "version-script",
-    commit: "commit-mesage",
+    commit: "commit-message",
     title: "pr-title",
     branch: "pr-base-branch",
     prDraft: "pr-draft",


### PR DESCRIPTION
Just ran into this while migrating, the lint works, the message is typood.