### PR TITLE
fix: deduplicate errors in pipeline runs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -132,6 +132,5 @@ import {
     }
   }
 })().catch((err) => {
-  core.error(err);
   core.setFailed(err.message);
 });


### PR DESCRIPTION
#### Description

This PR fixes duplicated error outputs in GitHub action pipeline runs by removing the `core.error(err)` call in the catch block, which was probably unintentionally kept in https://github.com/changesets/action/pull/289 while correctly replacing the other `console` statements, leading to the error being shown twice (as [reported by Chris](https://discord.com/channels/1499011163705573470/1499011165144092837/1540372708003680296)):

<img width="1014" height="450" alt="image" src="https://github.com/user-attachments/assets/c24289b6-ffbf-44b0-bcdb-c629f383479f" />
