### PR TITLE
Handle error when pushing git tags with the git CLI

### DIFF
--- a/.changeset/cool-rules-shine.md
+++ b/.changeset/cool-rules-shine.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": patch
+---
+
+Handle error when pushing git tags with the git CLI

--- a/src/github.ts
+++ b/src/github.ts
@@ -230,9 +230,8 @@ export class GitHub {
         });
       }
     } catch (err) {
-      // Assuming tag was manually pushed in custom publish script
       core.warning(
-        `Failed to create git tag "${tag}": ${(err as Error).message}`,
+        `Failed to create git tag "${tag}". Assuming it was manually pushed by the publish script: ${(err as Error).message}`,
       );
     }
   }

--- a/src/github.ts
+++ b/src/github.ts
@@ -213,25 +213,26 @@ export class GitHub {
   }
 
   async pushTag(tag: string) {
-    if (!this.pushWithGitCli) {
-      return this.octokit.rest.git
-        .createRef({
+    try {
+      if (!this.pushWithGitCli) {
+        await this.octokit.rest.git.createRef({
           ...context.repo,
           ref: `refs/tags/${tag}`,
           sha: context.sha,
-        })
-        .catch((err) => {
-          // Assuming tag was manually pushed in custom publish script
-          core.warning(`Failed to create tag ${tag}: ${err.message}`);
         });
+      } else {
+        await exec("git", ["push", "origin", tag], {
+          cwd: this.cwd,
+          env: {
+            ...process.env,
+            ...(await this.#getCliAuthEnv()),
+          } as Record<string, string>,
+        });
+      }
+    } catch (err) {
+      // Assuming tag was manually pushed in custom publish script
+      core.warning(`Failed to create tag ${tag}: ${(err as Error).message}`);
     }
-    await exec("git", ["push", "origin", tag], {
-      cwd: this.cwd,
-      env: {
-        ...process.env,
-        ...(await this.#getCliAuthEnv()),
-      } as Record<string, string>,
-    });
   }
 
   async prepareBranch(branch: string) {


### PR DESCRIPTION
fix #201 

The GitHub API also handle the error if it fails, so I don't see why the git CLI path also wouldn't